### PR TITLE
Add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+Thumbs.db
+#~
+.DS_Store
+\#*\#
+.\#*
+.*.swp
+.*.swo
+*.tmproj
+
+*.pyc
+
+docs/build
+__pycache__
+gmapi.log


### PR DESCRIPTION
This will prevent temporary editor swap files, pyc files, and generated documentation from showing up in git status, and stop it from being accidentally committed.
