### PR TITLE
Uppercase extensions (.MP3)

### DIFF
--- a/gmusicapi/api.py
+++ b/gmusicapi/api.py
@@ -709,7 +709,7 @@ class Api(UsesLog):
 
         try:
             for orig_fn in filenames:
-                extension = orig_fn.split(".")[-1]
+                extension = orig_fn.split(".")[-1].lower
 
                 if extension == "mp3":
                     all_file_handles.append(file(orig_fn))


### PR DESCRIPTION
I've got a bunch of files in my library with full uppercase names or just uppercase extensions. Currently gmusicapi thinks it can't upload (or even convert) them.
Added a simple .lower() on the extension to resolve this.
