### PR TITLE
Change "gm_type" to "type"

### DIFF
--- a/gmusicapi/protocol.py
+++ b/gmusicapi/protocol.py
@@ -250,7 +250,7 @@ class Metadata_Expectations(object):
     class albumArtUrl(_Metadata_Expectation):
         mutable = False
         optional = True #only seen when there is album art.
-    class gm_type(_Metadata_Expectation):
+    class type(_Metadata_Expectation):
         mutable = False
         val_type = "integer"
     class beatsPerMinute(_Metadata_Expectation):


### PR DESCRIPTION
I was getting the following errors on a small playlist sync script I made:

```
2012-11-20 03:01:28,417 - gmusicapi.Api - WARNING - Received an unexpected response from call loadplaylist.
2012-11-20 03:01:28,433 - gmusicapi.Api - WARNING - error was: Failed to validate field 'playlists' list schema: Failed to validate field 'playlist' list schema: additional properties not defined by 'properties' are not allowed in list item

2012-11-20 03:01:37,912 - gmusicapi.Api - WARNING - Received an unexpected response from call loadalltracks.
2012-11-20 03:01:37,938 - gmusicapi.Api - WARNING - error was: Failed to validate field 'playlist' list schema: additional properties not defined by 'properties' are not allowed in list item
```

After inspecting the log and reading about issue #36, I figured something similar was the cause. I'm not terribly familiar with this project, or Python in general, but changing "gm_type" to just "type" made the errors go away. I'm not sure if this is a proper fix, or if I broke something else, but here's the commit with my fix for consideration regardless.
