### PR TITLE
Fixes typo and adds url class

### DIFF
--- a/gmusicapi/protocol.py
+++ b/gmusicapi/protocol.py
@@ -273,7 +273,7 @@ class MetadataExpectations(object):
         val_type = "boolean"
 
     #introduced in issue 62:
-    class albumMatchedIf(_MetadataExpectation):
+    class albumMatchedId(_MetadataExpectation):
         mutable = False
         optional = True  # scan and match for entire albums?
 
@@ -281,6 +281,10 @@ class MetadataExpectations(object):
         mutable = False
         optional = True  # scan and match results pending?
         val_type = "boolean"
+
+    class url(_MetadataExpectation):
+        mutable = False
+        optional = True
 
 
     #Dependent metadata:


### PR DESCRIPTION
This is in response to [issue #62](https://github.com/simon-weber/Unofficial-Google-Music-API/issues/62). With this commit I am able to run the unittests and not get any of the warnings listed in that bug.

However, there is one error:

```
[ryan@sarang Unofficial-Google-Music-API]$ python2 -m gmusicapi.test.integration_test_api
Warning: this test suite _might_ modify the library it is run on.
Email: <redacted>
Password: 
.....2012-12-26 21:08:48,453 - gmusicapi.UnitTestedApi - ERROR - call to multidownload failed
F
======================================================================
FAIL: test_up_deletion (__main__.TestWCApiCalls)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ryan/git/vendor/Unofficial-Google-Music-API/gmusicapi/test/integration_test_api.py", line 210, in test_up_deletion
    self.run_steps("updel_")
  File "gmusicapi/test/utils.py", line 240, in run_steps
    raise self.fail("test {} step {} call to {} failure: {}".format(prefix, step, f.callname, f.res))
AssertionError: test updel_ step <bound method TestWCApiCalls.updel_1a_get_dl_info of <__main__.TestWCApiCalls testMethod=test_up_deletion>> call to get_song_download_info failure: {u'success': False}

----------------------------------------------------------------------
Ran 6 tests in 126.854s

FAILED (failures=1)
```
