### PR TITLE
fixed a small bug

### DIFF
--- a/gmusicapi/api.py
+++ b/gmusicapi/api.py
@@ -351,7 +351,7 @@ class Api(UsesLog):
         #The protocol expects a list of songs - could extend with accept_singleton
         info = self._wc_call("multidownload", [song_id])
 
-        return (info["url"], info["downloadCounts"][song_id])
+        return (getattr(info,"url",''), info["downloadCounts"][song_id])
 
     def get_stream_url(self, song_id):
         """Returns a url that points to a streamable version of this song. 


### PR DESCRIPTION
hi. currently, google does not return a download url on the multidownload request.
this is not a fixable problem on the api side but it can be handled better. i fixed it in get_song_download_info and it now returns an empty string if no download url is in googles reponse.
cheers
