### PR TITLE
Adds multi-part streaming support to get_stream_url (eg: All Access tracks)

### DIFF
--- a/gmusicapi/clients.py
+++ b/gmusicapi/clients.py
@@ -905,7 +905,10 @@ class Webclient(_Base):
 
         res = self._make_call(webclient.GetStreamUrl, song_id)
 
-        return res['url']
+        try:
+            return res['url']
+        except KeyError:
+            return res['urls']
 
     def copy_playlist(self, playlist_id, copy_name):
         """Copies the contents of a playlist to a new playlist. Returns the id of the new playlist.

--- a/gmusicapi/protocol/webclient.py
+++ b/gmusicapi/protocol/webclient.py
@@ -503,7 +503,8 @@ class GetStreamUrl(WcCall):
     _res_schema = {
         "type": "object",
         "properties": {
-            "url": {"type": "string"}
+            "url": {"type": "string", "required": False},
+            "urls": {"type": "array", "required": False}
         },
         "additionalProperties": False
     }


### PR DESCRIPTION
All-Access tracks stream differently than tracks you've added yourself, they are segmented across multiple files. This patch makes get_stream_url return a list of urls in this case, and a string in the standard case. I'm not entirely happy that you have to check to see if it returns a string or a list, but I can't really think of something better.

As an FYI, the urls that google is returning have a _range_ parameter and these ranges overlap. You can't just download each file and concatenate them together, you have to align them by skipping X bytes where X is the difference between the end range of the previous file and start range of the next file. I'll be implementing that logic into [GMusicFS](https://github.com/EnigmaCurry/GMusicFS) once this works from gmusicapi's end.

Thanks!
