### PR TITLE
Don't require artistId field [#153]

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -41,7 +41,7 @@ sj_track = {
         'trackType': {'type': 'string'},
         'storeId': {'type': 'string'},
         'albumId': {'type': 'string'},
-        'artistId': {'type': 'array', 'items': {'type': 'string', 'blank': True}},
+        'artistId': {'type': 'array', 'items': {'type': 'string', 'blank': True}, 'required': False},
         'nid': {'type': 'string'},
         'trackAvailableForPurchase': {'type': 'boolean'},
         'albumAvailableForPurchase': {'type': 'boolean'},


### PR DESCRIPTION
As explained in #153, artistId field is sometimes missing from All Access searches. This pullreq thus changes it to an optional element.
