### PR TITLE
Accept empty names of devices when getting settings.

### DIFF
--- a/gmusicapi/protocol/webclient.py
+++ b/gmusicapi/protocol/webclient.py
@@ -556,12 +556,12 @@ class GetSettings(WcCall):
             'date': {'type': 'integer',
                      'format': 'utc-millisec'},
             'id': {'type': 'string'},
-            'name': {'type': 'string'},
+            'name': {'type': 'string', 'blank': True},
             'type': {'type': 'string'},
             # only for type == PHONE:
             'model': {'type': 'string', 'required': False},
             'manufacturer': {'type': 'string', 'required': False},
-            'name': {'type': 'string', 'required': False},
+
             'carrier': {'type': 'string', 'required': False},
         },
     }


### PR DESCRIPTION
Empty name of devices bounded to the account accepted. Useful for getting your devices ids in gmusicfs [modded to use MobileClient API]
