### PR TITLE
added optional use_range_header to webclient's get_stream_audio

### DIFF
--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -153,10 +153,15 @@ class Webclient(_Base):
             return res['urls']
 
     @utils.enforce_id_param
-    def get_stream_audio(self, song_id):
+    def get_stream_audio(self, song_id, use_range_header=None):
         """Returns a bytestring containing mp3 audio for this song.
 
         :param song_id: a single song id
+        :param use_range_header: whether or not to use the HTTP range
+          header for All Access songs to save some bandwidth. default
+          value will make it try to use the header and if it fails then
+          strip the audio after it has been downloaded. if set to True
+          then it will raise an exception if the header does not work.
         """
 
         urls = self.get_stream_urls(song_id)
@@ -176,10 +181,21 @@ class Webclient(_Base):
         prev_end = 0
 
         for url, (start, end) in zip(urls, range_pairs):
-            headers = {
-                'Range': 'bytes=' + str(prev_end - start) + '-'
-            }
+            headers = None
+            if use_range_header or use_range_header is None:
+                headers = {
+                    'Range': 'bytes=' + str(prev_end - start) + '-'
+                }
             audio = self.session._rsession.get(url, headers=headers).content
+
+            #content length is not in the right range
+            if end - prev_end != len(audio) - 1:
+                #raise an exception if the user explicitly wanted the range header to be used
+                if use_range_header:
+                    raise RuntimeError('use_range_header is True but did not get the correct content length. (possibly bad HTTP proxy?)')
+                #otherwise strip the audio
+                audio = audio[prev_end - start:]
+
             stream_pieces.append(audio)
 
             prev_end = end + 1


### PR DESCRIPTION
#193

I made the header have 3 different options

Default is None: it will try to use the header and if it doesn't work then it will strip the audio.
True: try to use the header and if it doesn't work raise an exception.
False: don't use the header, strip the audio. Same behavior as before.

I dunno if the exception type/text is right, though. might wanna change that later.
