### PR TITLE
Use -q/-b instead of -qscale/-ab

### DIFF
--- a/gmusicapi/utils/utils.py
+++ b/gmusicapi/utils/utils.py
@@ -429,8 +429,8 @@ def transcode_to_mp3(filepath, quality=3, slice_start=None, slice_duration=None)
     An ID3 header is not included in the result.
 
     :param filepath: location of file
-    :param quality: if int, pass to -qscale. if string, pass to -ab
-                    -qscale roughly corresponds to libmp3lame -V0, -V1...
+    :param quality: if int, pass to -q:a. if string, pass to -b:a
+                    -q:a roughly corresponds to libmp3lame -V0, -V1...
     :param slice_start: (optional) transcode a slice, starting at this many seconds
     :param slice_duration: (optional) when used with slice_start, the number of seconds in the slice
 
@@ -451,9 +451,9 @@ def transcode_to_mp3(filepath, quality=3, slice_start=None, slice_duration=None)
         cmd.extend(['-ss', str(slice_start)])
 
     if isinstance(quality, int):
-        cmd.extend(['-qscale', str(quality)])
+        cmd.extend(['-q:a', str(quality)])
     elif isinstance(quality, basestring):
-        cmd.extend(['-ab', quality])
+        cmd.extend(['-b:a', quality])
     else:
         raise ValueError("quality must be int or string, but received %r" % quality)
 


### PR DESCRIPTION
-q is a concise alias for -qscale
I have seen no documentation for -ab anywhere, ~~and it doesn't work (at least for ffmpeg)~~ ok, it works. But it's still undocumented.
-b seems to be what we're looking for, based on [this](http://trac.ffmpeg.org/wiki/Encoding%20VBR%20%28Variable%20Bit%20Rate%29%20mp3%20audio).

The :a selects the audio stream - I don't know if this is redundant, but it seems safe and is used on that page, so might as well.
