### PR TITLE
Support random mixes without creating a radio station

### DIFF
--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -658,6 +658,110 @@ class Mobileclient(_Base):
 
         return stations[0].get('tracks', [])
 
+    def get_artist_mix_tracks(self, artist_id, num_tracks=25):
+        """Returns a list of dictionaries that each represent a track.
+
+        :param artist_id: the id of the artist being related to the tracks to retreive
+        :param num_tracks: the number of tracks to retrieve
+
+        See :func:`get_all_songs` for the format of a track dictionary.
+        """
+
+        seed = {'artistId': artist_id, 'seedType': 3}
+
+        res = self._make_call(mobileclient.ListMixTracks, seed,
+                              num_tracks, recently_played=[])
+
+        stations = res.get('data', {}).get('stations')
+        if not stations:
+            return []
+
+        return stations[0].get('tracks', [])
+
+    def get_artist_only_mix_tracks(self, artist_id, num_tracks=25):
+        """Returns a list of dictionaries that each represent a track.
+
+        :param artist_id: the id of the artist to retreive tracks from
+        :param num_tracks: the number of tracks to retrieve
+
+        See :func:`get_all_songs` for the format of a track dictionary.
+        """
+
+        seed = {'artistId': artist_id, 'seedType': 7}
+
+        res = self._make_call(mobileclient.ListMixTracks, seed,
+                              num_tracks, recently_played=[])
+
+        stations = res.get('data', {}).get('stations')
+        if not stations:
+            return []
+
+        return stations[0].get('tracks', [])
+
+    def get_album_mix_tracks(self, album_id, num_tracks=25):
+        """Returns a list of dictionaries that each represent a track.
+
+        :param album_id: the id of the album being related to the tracks to retreive
+        :param num_tracks: the number of tracks to retrieve
+
+        See :func:`get_all_songs` for the format of a track dictionary.
+        """
+
+        seed = {'albumId': album_id}
+
+        res = self._make_call(mobileclient.ListMixTracks, seed,
+                              num_tracks, recently_played=[])
+
+        stations = res.get('data', {}).get('stations')
+        if not stations:
+            return []
+
+        return stations[0].get('tracks', [])
+
+    def get_track_mix_tracks(self, track_id, num_tracks=25):
+        """Returns a list of dictionaries that each represent a track.
+
+        :param track_id: the id of the track being related to the tracks to retreive
+        :param num_tracks: the number of tracks to retrieve
+
+        See :func:`get_all_songs` for the format of a track dictionary.
+        """
+
+        seed = {}
+        if track_id[0] == 'T':
+            seed['trackId'] = track_id
+        else:
+            seed['trackLockerId'] = track_id
+
+        res = self._make_call(mobileclient.ListMixTracks, seed,
+                              num_tracks, recently_played=[])
+
+        stations = res.get('data', {}).get('stations')
+        if not stations:
+            return []
+
+        return stations[0].get('tracks', [])
+
+    def get_genre_mix_tracks(self, genre_id, num_tracks=25):
+        """Returns a list of dictionaries that each represent a track.
+
+        :param genre_id: the id of the genre to retrieve tracks from
+        :param num_tracks: the number of tracks to retrieve
+
+        See :func:`get_all_songs` for the format of a track dictionary.
+        """
+
+        seed = {'genreId': genre_id}
+
+        res = self._make_call(mobileclient.ListMixTracks, seed,
+                              num_tracks, recently_played=[])
+
+        stations = res.get('data', {}).get('stations')
+        if not stations:
+            return []
+
+        return stations[0].get('tracks', [])
+
     def search_all_access(self, query, max_results=50):
         """Queries the server for All Access songs and albums.
 

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -704,6 +704,54 @@ class ListStationTracks(McCall):
         return filtered
 
 
+class ListMixTracks(McCall):
+    _res_schema = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'kind': {'type': 'string'},
+            'data': {'type': 'object',
+                     'stations': {'type': 'array', 'items': sj_station},
+                     'required': False,
+                    },
+        },
+    }
+
+    static_headers = {'Content-Type': 'application/json'}
+    static_params = {'alt': 'json'}
+    static_method = 'POST'
+    static_url = sj_url + 'radio/stationfeed'
+
+    @staticmethod
+    def dynamic_data(seed, num_entries, recently_played):
+        """
+        :param seed
+        :param num_entries: maximum number of tracks to return
+        :param recently_played: a list of...song ids? never seen an example
+        """
+        #TODO
+        # clearly, this supports more than one at a time,
+        # but then that might introduce paging?
+        # I'll leave it for someone else
+
+        return json.dumps({'contentFilter': 1,
+                           'stations': [
+                               {
+                                   'numEntries': num_entries,
+                                   'seed': seed,
+                                   'recentlyPlayed': recently_played
+                               }
+                           ]})
+
+    @staticmethod
+    def filter_response(msg):
+        filtered = copy.deepcopy(msg)
+        if 'stations' in filtered['data']:
+            filtered['data']['stations'] = \
+                    ["<%s stations>" % len(filtered['data']['stations'])]
+        return filtered
+
+
 class BatchMutateStations(McBatchMutateCall):
     static_method = 'POST'
     static_url = sj_url + 'radio/editstation'


### PR DESCRIPTION
This implements random mixes for artists, albums, tracks, and genres.
It is also possible to retreive artist-only mixes which is identified
by a special seedType. Artist-related mixes use the seedType 3,
whereas artist-only mixes use seedType 7.

During the development of this I identifed the seedTypes as follows:
1: My Music Track Related Mix
2: All Access Track Related Mix
3: Artist Related Mix
4: Album Related Mix
5: Genre Mix
6: I'm feeling lucky radio
7: Artist-only Mix

It seems that there is also seedType 8, but I don't know what this is.

Splitting up all kinds of mixes into separate client methods seemed to
be more intuitive than using just one. What do you think?
