### PR TITLE
Change Sphinx config to insert code dir at beginning of sys.path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 
 from gmusicapi import __version__
 


### PR DESCRIPTION
This makes sure that the local dev code is used before installed versions of gmusicapi when building docs.
