### PR TITLE
Fix issues from #384

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 python:
   - '2.7'
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libav-tools libavcodec-extra-53
+addons:
+  apt:
+    packages:
+      - libav-tools
+      - libavcodec-extra-53
+sudo: false
 install:
   - python setup.py sdist --formats=zip -k
   - find ./dist -iname "*.zip" -print0 | xargs -0 pip install

--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -264,7 +264,7 @@ class Webclient(_Base):
 
             prev_end = end + 1
 
-        return ''.join(stream_pieces)
+        return b''.join(stream_pieces)
 
     @utils.accept_singleton(basestring)
     @utils.enforce_ids_param

--- a/gmusicapi/utils/utils.py
+++ b/gmusicapi/utils/utils.py
@@ -3,6 +3,7 @@
 """Utility functions used across api code."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+import ast
 from bisect import bisect_left
 from distutils import spawn
 import errno
@@ -568,7 +569,7 @@ def empty_arg_shortcircuit(return_code='[]', position=1):
     """Decorate a function to shortcircuit and return something immediately if
     the length of a positional arg is 0.
 
-    :param return_code: (optional) code to exec as the return value - default is a list.
+    :param return_code: (optional) simple expression to eval as the return value - default is a list
     :param position: (optional) the position of the expected list - default is 1.
     """
 
@@ -577,16 +578,13 @@ def empty_arg_shortcircuit(return_code='[]', position=1):
     # being mutated - there's only one, not a new one on each call.
     # Here we've got multiple things we'd like to
     # return, so we can't do that. Rather than make some kind of enum for
-    # 'accepted return values' I'm just allowing freedom to return anything.
-    # Less safe? Yes. More convenient? Definitely.
+    # 'accepted return values' I'm just allowing freedom to return basic values.
+    # ast.literal_eval only can evaluate most literal expressions (e.g. [] and {})
 
     @decorator
     def wrapper(function, *args, **kw):
         if len(args[position]) == 0:
-            # avoid polluting our namespace
-            ns = {}
-            exec('retval = ' + return_code, ns)
-            return ns['retval']
+            return ast.literal_eval(return_code)
         else:
             return function(*args, **kw)
 


### PR DESCRIPTION
I have the commits self-contained, so please let me know if you want this separated.

I wasn't able to replicate the build issue because I don't have the readthedocs builder (and didn't find any way to get it). The normal docs build went fine, though.
So instead, I am proposing a change that should avoid the whole issue. If using `literal_eval` is an issue, then maybe we could go the whole `defaultdict` route and change it to take a factory function.

This should also fix the problem with `get_stream_audio`