### PR TITLE
Add prompt for device ID in tests [#359]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ The server tests are a bit more complicated, as they exercise the actual Google 
 * `from gmusicapi import Musicmanager`
 * `Musicmanager.perform_oauth()`
 
-The server tests also require a device ID. Set this in the environment variable `GM_AA_D_ID`. This ideally should be the device ID of an Android device (use `Mobileclient.get_registered_devices()` to find the ID; strip out any leading `0x`). Using a desktop MAC address will work for most of the tests, but `mc_get_uploaded_track_stream_url` will fail.
+The server tests also require a device ID. You can set the environment variable `GM_AA_D_ID` or enter your ID at the prompt. Setting either to 'mac' will use Mobileclient.FROM_MAC_ADDRESS. Some tests will fail if not using an Android device ID (use `Mobileclient.get_registered_devices()` to find the ID; strip out any leading `0x`).
 
 Once you have all that set up, run the server tests:
 * `$ python -m gmusicapi.test.run_tests --group=server`

--- a/gmusicapi/test/run_tests.py
+++ b/gmusicapi/test/run_tests.py
@@ -91,12 +91,21 @@ def retrieve_auth():
         mm_kwargs['oauth_credentials'] = \
             credentials_from_refresh_token(mm_kwargs['oauth_credentials'])
 
-    if 'GM_AA_D_ID' not in os.environ:
-        print('an android id must be provided in the env var GM_AA_D_ID')
+    mc_kwargs = wc_kwargs.copy()
+
+    try:
+        android_id = os.environ['GM_AA_D_ID']
+    except KeyError:
+        android_id = input("Device ID ('mac' for FROM_MAC_ADDRESS): ")
+
+    if android_id == "mac":
+        android_id = Mobileclient.FROM_MAC_ADDRESS
+
+    if not android_id:
+        print('a device id must be provided')
         sys.exit(1)
 
-    mc_kwargs = wc_kwargs.copy()
-    mc_kwargs['android_id'] = os.environ['GM_AA_D_ID']
+    mc_kwargs['android_id'] = android_id
 
     return (wc_kwargs, mc_kwargs, mm_kwargs)
 


### PR DESCRIPTION
* Prefers the env var; prompts if it doesn't exist.
* Allows 'mac' to be given to use Mobileclient.FROM_MAC_ADDRESS.