### PR TITLE
Doc fix and PyCryptodome

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -29,7 +29,7 @@ installed and in your system path, along with at least libmp3lame.
    - Download pre-built binaries of
      `avconv <http://johnvansickle.com/libav/>`__ or `ffmpeg <http://johnvansickle.com/ffmpeg/>`__
      and `edit your path <http://www.troubleshooters.com/linux/prepostpath.htm>`__
-     to include the directory that contains avconv.exe/ffmpeg.exe.
+     to include the directory that contains avconv/ffmpeg.
 
  - Mac
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ py==1.4.26
 pyOpenSSL==0.15.1
 pyasn1==0.1.7
 pycparser==2.13
-pycrypto==2.6.1
+pycryptodome==3.3.1
 pyflakes==0.8.1
 python-dateutil==2.2
 python-gflags==2.0


### PR DESCRIPTION
Just a couple small changes that I would've felt ridiculous opening separate PRs for.

* Switching to PyCryptodome in requirements.
* Fixed a copy/paste mistake I made in the docs a long, long time ago in a commit far, far away. Silly Munch, exe's are for Windows.