### PR TITLE
Return matched result on match even when matching is disabled [#412]

### DIFF
--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -515,7 +515,7 @@ class Musicmanager(_Base):
                 matched[path] = sample_res.server_track_id
 
                 if not enable_matching:
-                    self.logger.exception("'%s' was matched without matching enabled", path)
+                    self.logger.error("'%s' was matched without matching enabled", path)
 
             elif sample_res.response_code == upload_pb2.TrackSampleResponse.UPLOAD_REQUESTED:
                 to_upload[sample_res.server_track_id] = (path, track, False)

--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -512,9 +512,9 @@ class Musicmanager(_Base):
             if sample_res.response_code == upload_pb2.TrackSampleResponse.MATCHED:
                 self.logger.info("matched '%s' to sid %s", path, sample_res.server_track_id)
 
-                if enable_matching:
-                    matched[path] = sample_res.server_track_id
-                else:
+                matched[path] = sample_res.server_track_id
+
+                if not enable_matching:
                     self.logger.exception("'%s' was matched without matching enabled", path)
 
             elif sample_res.response_code == upload_pb2.TrackSampleResponse.UPLOAD_REQUESTED:


### PR DESCRIPTION
It's Musicmanager.upload's job to return the upload call results; it doesn't matter if that result was intended or not. Not doing so breaks users' expectations and code.