### PR TITLE
Check if oauth_credentials is basestring, not str, in Musicmanager.login [#423]

### DIFF
--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -171,7 +171,7 @@ class Musicmanager(_Base):
         Return True on success; see :py:func:`login` for params.
         """
 
-        if isinstance(oauth_credentials, str):
+        if isinstance(oauth_credentials, basestring):
             oauth_file = oauth_credentials
             if oauth_file == OAUTH_FILEPATH:
                 utils.make_sure_path_exists(os.path.dirname(OAUTH_FILEPATH), 0o700)


### PR DESCRIPTION
Didn't get a response from the Issue OP, so I installed Python 2.7 again and tested the fix myself.