### PR TITLE
Exception handling

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -3,7 +3,7 @@
 """Calls made by the mobile client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 from future import standard_library
-from future.utils import raise_from
+from six import raise_from
 
 standard_library.install_aliases()
 from builtins import *  # noqa

--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -3,7 +3,7 @@
 """Calls made by the Music Manager (related to uploading)."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 from future import standard_library
-from future.utils import raise_from
+from six import raise_from
 
 standard_library.install_aliases()
 from builtins import *  # noqa

--- a/gmusicapi/protocol/shared.py
+++ b/gmusicapi/protocol/shared.py
@@ -222,7 +222,7 @@ class Call(with_metaclass(BuildRequestMeta, object)):
 
                 if cls.gets_logged:
                     err_msg += "\n(requests kwargs: %r)" % (safe_req_kwargs)
-                    err_msg += "\n(response was: %r)" % response.content
+                    err_msg += "\n(response was: %r)" % response.text
 
                 raise CallFailure(err_msg, call_name)
 
@@ -233,8 +233,8 @@ class Call(with_metaclass(BuildRequestMeta, object)):
                        " The call may still have succeeded, but it's unlikely.")
             if cls.gets_logged:
                 err_msg += "\n(requests kwargs: %r)" % (safe_req_kwargs)
-                err_msg += "\n(response was: %r)" % response.content
-                log.exception("could not parse %s response: %r", call_name, response.content)
+                err_msg += "\n(response was: %r)" % response.text
+                log.exception("could not parse %s response: %r", call_name, response.text)
             else:
                 log.exception("could not parse %s response: (omitted)", call_name)
 
@@ -258,7 +258,7 @@ class Call(with_metaclass(BuildRequestMeta, object)):
                        "(response was: {content!r})").format(
                            e_message=e.message,
                            req_kwargs=safe_req_kwargs,
-                           content=response.content)
+                           content=response.text)
             raise_from(CallFailure(err_msg, e.callname), e)
 
         except ValidationException as e:
@@ -267,7 +267,7 @@ class Call(with_metaclass(BuildRequestMeta, object)):
             err_msg += "\n\n%s\n" % e
 
             if cls.gets_logged:
-                raw_response = response.content
+                raw_response = response.text
 
                 if len(raw_response) > 10000:
                     raw_response = raw_response[:10000] + '...'

--- a/gmusicapi/protocol/webclient.py
+++ b/gmusicapi/protocol/webclient.py
@@ -3,7 +3,7 @@
 """Calls made by the web client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 from future import standard_library
-from future.utils import raise_from
+from six import raise_from
 
 standard_library.install_aliases()
 from builtins import *  # noqa

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'pyopenssl',
         'ndg-httpsclient',
         'pyasn1',
+        'six',                                    # raise_from on Python 3
         'future',
     ] + dynamic_requires,
     classifiers=[


### PR DESCRIPTION
Fixes one str/bytes mismatch on Python 3 by using response.text rather than response.content.

Also switches the raise_from calls from python-future to six. This for a couple of reasons relating to Python 3 behavior:
 
* future searches globals/locals for the exception class. This causes a NameError when you do something like ``except ValueError on e`` when you're catching validictory's exceptions which sublcass ValueError.
* Even if you were to import all the exceptions needed, future fails for any exceptions that have arguments (e.g. validictory.FieldValidationError) since it tries to be too smart in handling both exception classes and exception class instances. It ends up instantiating a new exception rather than using the exception instance it's passed.

six.raise_from avoids both these drawbacks and fits the use cases in gmusicapi.