### PR TITLE
Add ability to use a playlist as a station seed

### DIFF
--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -672,13 +672,15 @@ class Mobileclient(_Base):
 
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
-                       genre_id=None):
+                       genre_id=None, playlist_token=None):
         """Creates an All Access radio station and returns its id.
 
         :param name: the name of the station to create
         :param \*_id: the id of an item to seed the station from.
-          Exactly one of these params must be provided, or ValueError
-          will be raised.
+        :param playlist_token: The shareToken of a playlist to seed the station from.
+
+        Exactly one of the id/token params must be provided, or ValueError
+        will be raised.
         """
         # TODO could expose include_tracks
 
@@ -700,6 +702,9 @@ class Mobileclient(_Base):
         if genre_id is not None:
             seed['genreId'] = genre_id
             seed['seedType'] = 5
+        if playlist_token is not None:
+            seed['playlistShareToken'] = playlist_token
+            seed['seedType'] = 8
 
         if len(seed) > 2:
             raise ValueError('exactly one {track,artist,album,genre}_id must be provided')

--- a/gmusicapi/test/server_tests.py
+++ b/gmusicapi/test/server_tests.py
@@ -373,7 +373,8 @@ class ClientTests(object):
                                ('up song', {'track_id': self.user_songs[0].sid}),
                                ('artist', {'artist_id': TEST_AA_ARTIST_ID}),
                                ('album', {'album_id': TEST_AA_ALBUM_ID}),
-                               ('genre', {'genre_id': TEST_AA_GENRE_ID})):
+                               ('genre', {'genre_id': TEST_AA_GENRE_ID}),
+                               ('playlist', {'playlist_token': TEST_PLAYLIST_SHARETOKEN})):
             station_ids.append(
                 self.mc.create_station(prefix + ' ' + TEST_STATION_NAME, **kwargs))
 


### PR DESCRIPTION
This may or may not require the API version bump in #428.