### PR TITLE
Use str(e) instead of e.message

### DIFF
--- a/gmusicapi/protocol/shared.py
+++ b/gmusicapi/protocol/shared.py
@@ -256,7 +256,7 @@ class Call(with_metaclass(BuildRequestMeta, object)):
             err_msg = ("{e_message}\n"
                        "(requests kwargs: {req_kwargs!r})\n"
                        "(response was: {content!r})").format(
-                           e_message=e.message,
+                           e_message=str(e),
                            req_kwargs=safe_req_kwargs,
                            content=response.text)
             raise_from(CallFailure(err_msg, e.callname), e)


### PR DESCRIPTION
Hadn't run into this since the port, but it popped up in #431. e.message was deprecated in 2.6 and removed in 3.0.