### PR TITLE
Allow all thumbs upped songs to be retrieved

### DIFF
--- a/docs/source/reference/mobileclient.rst
+++ b/docs/source/reference/mobileclient.rst
@@ -48,6 +48,7 @@ Store track ids can be used in most places that normal song ids can
 Note that sometimes they are stored under the ``'nid'`` key, not the ``'id'`` key.
 
 .. automethod:: Mobileclient.get_all_songs
+.. automethod:: Mobileclient.get_thumbsup_songs
 .. automethod:: Mobileclient.get_stream_url
 .. automethod:: Mobileclient.change_song_metadata
 .. automethod:: Mobileclient.delete_songs

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -160,6 +160,24 @@ class Mobileclient(_Base):
 
         return tracks
 
+    def get_thumbsup_songs(self, incremental=False, include_deleted=False):
+        """Returns a list of dictionaries that each represent a thumbs upped song.
+
+        :param incremental: if True, return a generator that yields lists
+          of at most 1000 tracks
+          as they are retrieved from the server. This can be useful for
+          presenting a loading bar to a user.
+
+        :param include_deleted: if True, include tracks that have been deleted
+          in the past.
+
+        See :func:`get_all_songs` for the format of a track dictionary.
+        """
+
+        tracks = self._get_all_items(mobileclient.ListEphemeralThumbsUpTracks, incremental, include_deleted)
+
+        return tracks
+
     @utils.accept_singleton(dict)
     @utils.empty_arg_shortcircuit
     def change_song_metadata(self, songs):

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -636,6 +636,14 @@ class ListPlaylists(McListCall):
     static_url = sj_url + 'playlistfeed'
 
 
+class ListEphemeralThumbsUpTracks(McListCall):
+    item_schema = sj_plentry
+    filter_text = 'plentries'
+
+    static_method = 'POST'
+    static_url = sj_url + 'ephemeral/top'
+
+
 class ListPlaylistEntries(McListCall):
     item_schema = sj_plentry
     filter_text = 'plentries'


### PR DESCRIPTION
When using AA, it's possible to have songs that have been thumbs upped but don't exist in your local library at all. 

Add a new method `get_thumbsup_songs` that can retrieve these.