### PR TITLE
Add locale and subscription parameters to Mobileclient session [#444]

### DIFF
--- a/docs/source/reference/mobileclient.rst
+++ b/docs/source/reference/mobileclient.rst
@@ -12,6 +12,13 @@ Setup and login
 .. automethod:: Mobileclient.login
 .. automethod:: Mobileclient.logout
 .. automethod:: Mobileclient.is_authenticated
+.. attribute:: Mobileclient.locale
+
+	The locale of the Mobileclient session used to localize some responses.
+
+	Should be an `ICU <http://www.localeplanet.com/icu/>`__ locale supported by Android.
+
+	Set on authentication with :func:`login` but can be changed at any time.
 
 Account Management
 ------------------

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -33,6 +33,21 @@ class Mobileclient(_Base):
                                            validate,
                                            verify_ssl)
 
+    @property
+    def locale(self):
+        """The locale of the Mobileclient session used to localize some responses.
+
+        Should be an `ICU <http://www.localeplanet.com/icu/>`__ locale supported by Android.
+
+        Set on authentication with :func:`login` but can be changed at any time.
+        """
+
+        return self.session._locale
+
+    @locale.setter
+    def locale(self, locale):
+        self.session._locale = locale
+
     @utils.cached_property(ttl=600)
     def is_subscribed(self):
         """Returns the subscription status of the Google Music account.
@@ -55,7 +70,7 @@ class Mobileclient(_Base):
         else:
             return False
 
-    def login(self, email, password, android_id):
+    def login(self, email, password, android_id, locale='en_US'):
         """Authenticates the Mobileclient.
         Returns ``True`` on success, ``False`` on failure.
 
@@ -71,6 +86,10 @@ class Mobileclient(_Base):
           but appears to work fine in testing.
           If a valid MAC address cannot be determined on this machine
           (which is often the case when running on a VPS), raise OSError.
+
+        :param locale: `ICU <http://www.localeplanet.com/icu/>`__ locale
+          used to localize certain responses. This must be a locale supported
+          by Android. Defaults to ``'en_US'``.
         """
         # TODO 2fa
 
@@ -93,6 +112,8 @@ class Mobileclient(_Base):
 
         self.android_id = android_id
         self.logger.info("authenticated")
+
+        self.locale = locale
 
         return True
 

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -66,9 +66,12 @@ class Mobileclient(_Base):
 
         for item in res['data']['entries']:
             if item['key'] == 'isNautilusUser' and item['value'] == 'true':
-                return True
+                self.session._is_subscribed = True
+                break
         else:
-            return False
+            self.session._is_subscribed = False
+
+        return self.session._is_subscribed
 
     def login(self, email, password, android_id, locale='en_US'):
         """Authenticates the Mobileclient.
@@ -114,6 +117,9 @@ class Mobileclient(_Base):
         self.logger.info("authenticated")
 
         self.locale = locale
+
+        if self.is_subscribed:
+            self.logger.info("subscribed")
 
         return True
 

--- a/gmusicapi/session.py
+++ b/gmusicapi/session.py
@@ -175,6 +175,7 @@ class Mobileclient(_Base):
         super(Mobileclient, self).__init__(*args, **kwargs)
         self._master_token = None
         self._authtoken = None
+        self._locale = None
 
     def login(self, email, password, android_id, *args, **kwargs):
         """
@@ -206,6 +207,14 @@ class Mobileclient(_Base):
 
     def _send_with_auth(self, req_kwargs, desired_auth, rsession):
         if desired_auth.oauth:
+            # Default to English (United States) if no locale given.
+            if not self._locale:
+                self._locale = 'en_US'
+
+            # Set locale for all Mobileclient calls.
+            req_kwargs.setdefault('params', {})
+            req_kwargs['params'].update({'hl': self._locale})
+
             req_kwargs.setdefault('headers', {})
 
             # does this expire?

--- a/gmusicapi/session.py
+++ b/gmusicapi/session.py
@@ -176,6 +176,7 @@ class Mobileclient(_Base):
         self._master_token = None
         self._authtoken = None
         self._locale = None
+        self._is_subscribed = None
 
     def login(self, email, password, android_id, *args, **kwargs):
         """
@@ -214,6 +215,11 @@ class Mobileclient(_Base):
             # Set locale for all Mobileclient calls.
             req_kwargs.setdefault('params', {})
             req_kwargs['params'].update({'hl': self._locale})
+
+            if self._is_subscribed:
+                req_kwargs['params'].update({'tier': 'aa'})
+            else:
+                req_kwargs['params'].update({'tier': 'fr'})
 
             req_kwargs.setdefault('headers', {})
 


### PR DESCRIPTION
* Add locale property to Mobileclient.
* Locale and subscription parameters set on underlying session.
* Set locale/is_subscribed properties on authentication with Mobileclient.login, so they're available immediately for all authenticated calls.