### PR TITLE
Add add_store_tracks method to Mobileclient

### DIFF
--- a/docs/source/reference/mobileclient.rst
+++ b/docs/source/reference/mobileclient.rst
@@ -61,6 +61,7 @@ Note that sometimes they are stored under the ``'nid'`` key, not the ``'id'`` ke
 .. automethod:: Mobileclient.get_promoted_songs
 .. automethod:: Mobileclient.increment_song_playcount
 .. automethod:: Mobileclient.add_store_track
+.. automethod:: Mobileclient.add_store_tracks
 
 Playlists
 ---------

--- a/gmusicapi/test/server_tests.py
+++ b/gmusicapi/test/server_tests.py
@@ -269,7 +269,7 @@ class ClientTests(object):
         user_sids.append(uploaded[fname])
 
         if test_subscription_features():
-            store_sids.append(self.mc.add_store_track(TEST_STORE_SONG_ID))
+            store_sids.append(self.mc.add_store_tracks(TEST_STORE_SONG_ID)[0])
 
         # we test get_all_songs here so that we can assume the existance
         # of the song for future tests (the servers take time to sync an upload)


### PR DESCRIPTION
Implements adding multiple songs to library through the trackbatch endpoint.