### PR TITLE
Perform session logout on Musicmanager uploader_id exceptions

### DIFF
--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -199,6 +199,7 @@ class Musicmanager(_Base):
         if uploader_id is None:
             mac_int = getmac()
             if (mac_int >> 40) % 2:
+                self.session.logout()
                 raise OSError('a valid MAC could not be determined.'
                               ' Provide uploader_id (and be'
                               ' sure to provide the same one on future runs).')
@@ -210,6 +211,7 @@ class Musicmanager(_Base):
             uploader_id = utils.create_mac_string(mac_int)
 
         if not utils.is_valid_mac(uploader_id):
+            self.session.logout()
             raise ValueError('uploader_id is not in a valid form.'
                              '\nProvide 6 pairs of hex digits'
                              ' with capital letters',


### PR DESCRIPTION
Without this, the session is left open and session.is_authenticated is left
set to True when a valid uploader_id is not given or determined.
Any Musicmanager call made after this would result in a vague TypeError
rather than a NotLoggedIn exception.

Don't ask me how I came across this, because I don't remember what I was doing in the interpreter at the time it popped up. This shouldn't actually be an issue in any proper code , but it's probably the correct thing to do.