### PR TITLE
Added 'trackCount' field

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -216,6 +216,7 @@ sj_album = {
         'name': {'type': 'string'},
         'albumArtist': {'type': 'string'},
         'albumArtRef': {'type': 'string', 'required': False},
+        'trackCount': {'type': 'integer', 'required': False},
         'albumId': {'type': 'string'},
         'artist': {'type': 'string', 'blank': True},
         'artistId': {'type': 'array', 'items': {'type': 'string', 'blank': True}},


### PR DESCRIPTION
This field is returned when calling get_album_info() and without the definition of this field a validation exception will occur.
