### PR TITLE
Add warnings about lack of testing/support for Webclient

### DIFF
--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -5,20 +5,18 @@ Client Interfaces
 =================
 
 gmusicapi currently has three main interfaces:
-one for the music.google.com webclient, 
+one for the music.google.com webclient,
 one for the Android App, and
 one for the Music Manager. The big differences are:
 
 * :py:class:`Webclient` development has mostly ceased, with the :py:class:`Mobileclient`
-  superceding it.
-* :py:class:`Musicmanager` is used only for uploading, while
-  :py:class:`Webclient`/:py:class:`Mobileclient`
-  support everything but uploading.
+  superceding it. It is not tested nor well supported.
+* :py:class:`Musicmanager` is used for uploading and downloading, while
+  :py:class:`Mobileclient` supports everything but uploading.
 * :py:class:`Webclient`/:py:class:`Mobileclient` require a plaintext email and password to login, while
   :py:class:`Musicmanager` uses `OAuth2
   <https://developers.google.com/accounts/docs/OAuth2#installed>`__.
-* :py:class:`Webclient` and :py:class:`Mobileclient` both support streaming, but
-  :py:class:`Mobileclient` requires that the Google Music app has been installed
+* :py:class:`Mobileclient` supports streaming but requires that the Google Play Music app has been installed
   and run before use.
 
 .. toctree::

--- a/docs/source/reference/webclient.rst
+++ b/docs/source/reference/webclient.rst
@@ -1,8 +1,15 @@
 .. _webclient:
 .. currentmodule:: gmusicapi.clients
+.. |br| raw:: html
+
+   <br />
 
 Webclient Interface
 ===================
+
+**WARNING** |br|
+**Webclient functionality is not tested nor well supported.**  |br|
+**Use** :class:`Mobileclient` **or** :class:`Musicmanager` **if possible.**
 
 .. autoclass:: Webclient
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -104,7 +104,8 @@ If you need both library management and uploading, just create
 multiple client instances.
 
 There is also the :py:class:`Webclient`, which is a mostly-deprecated
-interface that provides similar features to the Mobileclient.
+interface. It is not tested nor well supported. Use :class:`Mobileclient`
+or :class:`Musicmanager` if possible.
 
 The reference section has complete information on all clients:
 

--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -5,9 +5,11 @@ from past.builtins import basestring
 standard_library.install_aliases()
 from builtins import *  # noqa
 from urllib.parse import urlparse, parse_qsl
+import warnings
 
 import gmusicapi
 from gmusicapi.clients.shared import _Base
+from gmusicapi.exceptions import GmusicapiWarning
 from gmusicapi.protocol import webclient
 from gmusicapi.utils import utils
 import gmusicapi.session
@@ -37,6 +39,12 @@ class Webclient(_Base):
     _session_class = gmusicapi.session.Webclient
 
     def __init__(self, debug_logging=True, validate=True, verify_ssl=True):
+        warnings.warn(
+            "Webclient functionality is not tested nor well supported. "
+            "Use Mobileclient or Musicmanager if possible.",
+            GmusicapiWarning
+        )
+
         super(Webclient, self).__init__(self.__class__.__name__,
                                         debug_logging,
                                         validate,


### PR DESCRIPTION
This should hit all the marks.

* Display a warning when instantiating ``Webclient``.
* Add a bold warning at the top of the Webclient Interface docs.
* Update usage docs with stronger warning and alternatives.
* Update interface comparison and de-emphasize Webclient interface.