### PR TITLE
Update mutagen requirement

### DIFF
--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -283,12 +283,6 @@ class UploadMetadata(MmCall):
             if null_field not in audio:
                 track_set(null_field, '')
 
-        if isinstance(audio, mutagen.mp3.EasyMP3):
-            # Mutagen tags the album artist as `performer` in EasyMP3 tags.
-            # https://bitbucket.org/lazka/mutagen/issue/195
-            if 'performer' in audio:
-                track_set('album_artist', audio['performer'][0])
-
         # Mass-populate the rest of the simple fields.
         # Merge shared and unshared fields into {mutagen: Track}.
         fields = dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ idna==2.1
 ipaddress==1.0.16
 MechanicalSoup==0.4.0
 mock==2.0.0
-mutagen==1.32
+mutagen==1.34
 ndg-httpsclient==0.4.0
 oauth2client==2.1.0
 pbr==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         'validictory >= 0.8.0, != 0.9.2',         # error messages
         'decorator >= 3.3.1',                     # > 3.0 likely work, but not on pypi
-        'mutagen >= 1.18',                        # EasyID3 module renaming
+        'mutagen >= 1.34',                        # EasyID3 TPE2 mapping to albumartist
         ('requests >= 1.1.0, != 1.2.0,'           # session.close, memory view TypeError
          '!= 2.2.1, != 2.8.0, != 2.8.1'),
         'python-dateutil >= 1.3, != 2.0',         # 2.0 is python3-only


### PR DESCRIPTION
They have added file-like object support which may or may not be useful at some point. EasyID3 now maps TPE2 to ``albumartist`` rather than ``performer``. Among many general changes/updates like dropping Python 2.6 support.