### PR TITLE
Remove leftover traces of Webclient testing

### DIFF
--- a/gmusicapi/test/local_tests.py
+++ b/gmusicapi/test/local_tests.py
@@ -18,7 +18,7 @@ from proboscis.asserts import (
 from proboscis import test
 
 import gmusicapi.session
-from gmusicapi.clients import Webclient, Musicmanager
+from gmusicapi.clients import Mobileclient, Musicmanager
 from gmusicapi.exceptions import AlreadyLoggedIn
 from gmusicapi.protocol.shared import authtypes
 from gmusicapi.protocol import mobileclient
@@ -51,7 +51,7 @@ def longest_increasing_sub():
 # clients
 #
 # this feels like a dumb pattern, but I can't think of a better way
-names = ('Webclient', 'Musicmanager')
+names = ('Mobileclient', 'Musicmanager')  # Webclient removed since testing is disabled.
 Clients = namedtuple('Clients', [n.lower() for n in names])
 
 
@@ -70,8 +70,11 @@ def create_clients():
 
 @test
 def no_client_auth_initially():
-    wc = Webclient()
-    assert_false(wc.is_authenticated())
+    # wc = Webclient()
+    # assert_false(wc.is_authenticated())
+
+    mc = Mobileclient()
+    assert_false(mc.is_authenticated())
 
     mm = Musicmanager()
     assert_false(mm.is_authenticated())

--- a/gmusicapi/test/server_tests.py
+++ b/gmusicapi/test/server_tests.py
@@ -27,7 +27,7 @@ import requests
 from requests.exceptions import SSLError
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-from gmusicapi import Webclient, Musicmanager, Mobileclient
+from gmusicapi import Musicmanager, Mobileclient
 # from gmusicapi.protocol import mobileclient
 from gmusicapi.protocol.shared import authtypes
 from gmusicapi.utils.utils import retry, id_or_nid
@@ -100,21 +100,23 @@ class SslVerificationTests(object):
 
     @test
     def clients_verify_by_default(self):
-        for client_cls in (Webclient, Mobileclient, Musicmanager):
+        # Webclient removed since testing is disabled.
+        for client_cls in (Mobileclient, Musicmanager):
             assert_raises(SSLError, self.request_invalid_site, client_cls())
 
     @test
     def disable_client_verify(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=InsecureRequestWarning)
-            for client_cls in (Webclient, Mobileclient, Musicmanager):
+            # Webclient removed since testing is disabled.
+            for client_cls in (Mobileclient, Musicmanager):
                 self.request_invalid_site(client_cls(verify_ssl=False))  # should not raise SSLError
 
 
 @test(groups=['server'])
 class ClientTests(object):
     # set on the instance in login
-    wc = None  # webclient
+    # wc = None  # webclient
     mm = None  # musicmanager
     mc = None  # mobileclient
 


### PR DESCRIPTION
Not all Webclient testing was disabled previously. And much of the setup code remained intact.

This PR: 
* Removes or comments out any remaining Webclient testing and setup until a time when it can be re-enabled.
* Changed the auth retrieval and verification to use Mobileclient. This is particularly useful as the Webclient did not support app-specific password. Meaning that 2FA users (ok, me) couldn't test Mobileclient without monkeying with the run_tests code to make the Webclient auth check succeed despite Webclient not even being tested.

I have a bigger testing rewrite in my head using pytest that will eventually get done. Until then, this makes the most sense to do.