### PR TITLE
Fix undefined name in require_subscription decorator

### DIFF
--- a/gmusicapi/utils/utils.py
+++ b/gmusicapi/utils/utils.py
@@ -623,7 +623,7 @@ def require_subscription(function, *args, **kwargs):
     self = args[0]
 
     if not self.is_subscribed:
-        raise NotSubscribed("%s requires a subscription." % func.__name__)
+        raise NotSubscribed("%s requires a subscription." % function.__name__)
 
     return function(*args, **kwargs)
 


### PR DESCRIPTION
Somehow I've never noticed that I made an editing mistake that would make this fail with an undefined name. ``Ctrl-z`` will be the death of me one day.