### PR TITLE
Add podcast functionality

### DIFF
--- a/docs/source/reference/mobileclient.rst
+++ b/docs/source/reference/mobileclient.rst
@@ -93,6 +93,16 @@ A subscription is required in other countries.
 .. automethod:: Mobileclient.delete_stations
 .. automethod:: Mobileclient.get_station_tracks
 
+Podcasts
+--------
+
+.. automethod:: Mobileclient.get_all_podcast_series
+.. automethod:: Mobileclient.get_all_podcast_episodes
+.. automethod:: Mobileclient.add_podcast_series
+.. automethod:: Mobileclient.delete_podcast_series
+.. automethod:: Mobileclient.edit_podcast_series
+.. automethod:: Mobileclient.get_podcast_episode_stream_url
+
 Search
 ------
 Search Google Play for information about artists, albums, tracks, and more.
@@ -101,10 +111,14 @@ Search Google Play for information about artists, albums, tracks, and more.
 .. automethod:: Mobileclient.get_genres
 .. automethod:: Mobileclient.get_album_info
 .. automethod:: Mobileclient.get_artist_info
+.. automethod:: Mobileclient.get_podcast_episode_info
+.. automethod:: Mobileclient.get_podcast_series_info
 .. automethod:: Mobileclient.get_track_info
 
 Misc
 ----
 
+.. automethod:: Mobileclient.get_browse_podcast_hierarchy
+.. automethod:: Mobileclient.get_browse_podcast_series
 .. automethod:: Mobileclient.get_listen_now_items
 .. automethod:: Mobileclient.get_listen_now_situations

--- a/example.py
+++ b/example.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from builtins import *  # noqa
 

--- a/gmusicapi/_version.py
+++ b/gmusicapi/_version.py
@@ -1,1 +1,3 @@
+# -*- coding: utf-8 -*-
+
 __version__ = u"10.0.2rc1"

--- a/gmusicapi/clients/__init__.py
+++ b/gmusicapi/clients/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from gmusicapi.clients.webclient import Webclient
 from gmusicapi.clients.musicmanager import Musicmanager, OAUTH_FILEPATH

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1376,6 +1376,47 @@ class Mobileclient(_Base):
 
         return self._make_call(mobileclient.GetPodcastSeries, podcast_series_id, max_episodes)
 
+    def get_podcast_episode_info(self, podcast_episode_id):
+        """Retrieves information about a podcast episode.
+
+        :param podcast_episode_id: A podcast episode id (hint: they always start with 'D').
+
+        Returns a dict, eg::
+
+            {
+                'art': [
+                    {
+                        'aspectRatio': '1',
+                        'autogen': False,
+                        'kind': 'sj#imageRef',
+                        'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5...'
+                    }
+                ],
+                'description': 'Sarah Jessica Parker\xa0(Sex and the City) '
+                               'chats with Chris about growing up without '
+                               'television, her time on\xa0Square Pegs\xa0and '
+                               'her character in\xa0L.A. Story. Sarah Jessica '
+                               'then talks about how she felt when she first '
+                               'got the part of Carrie on\xa0Sex and the '
+                               'City,\xa0how she dealt with her sudden '
+                               'celebrity of being Carrie Bradshaw and they '
+                               'come up with a crazy theory about the show! '
+                               'They also talk about Sarah Jessica’s new '
+                               'show\xa0Divorce\xa0on HBO!',
+                'durationMillis': '5101000',
+                'episodeId': 'Dcz67vtkhrerzh4hptfqpadt5vm',
+                'explicitType': '1',
+                'fileSize': '40995252',
+                'publicationTimestampMillis': '1475640000000',
+                'seriesId': 'Iliyrhelw74vdqrro77kq2vrdhy',
+                'seriesTitle': 'The Nerdist',
+                'title': 'Sarah Jessica Parker'
+            }
+
+        """
+
+        return self._make_call(mobileclient.GetPodcastEpisode, podcast_episode_id)
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1302,6 +1302,80 @@ class Mobileclient(_Base):
 
         return res['mutate_response'][0]['id']
 
+    def get_podcast_series_info(self, podcast_series_id, max_episodes=50):
+        """Retrieves information about a podcast series.
+
+        :param podcast_series_id: A podcast series id (hint: they always start with 'I').
+        :param max_episodes: Maximum number of episodes to retrieve
+
+        Returns a dict, eg::
+
+            {
+                'art': [
+                    {
+                        'aspectRatio': '1',
+                        'autogen': False,
+                        'kind': 'sj#imageRef',
+                        'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5W80uMOfq...'
+                    }
+                ],
+                'author': 'Chris Hardwick',
+                'continuationToken': '',
+                'description': 'I am Chris Hardwick. I am on TV a lot and have a blog at '
+                               'nerdist.com. This podcast is basically just me talking about '
+                               'stuff and things with my two nerdy friends Jonah Ray and Matt '
+                               'Mira, and usually someone more famous than all of us. '
+                               'Occasionally we swear because that is fun. I hope you like '
+                               "it, but if you don't I'm sure you will not hesitate to unfurl "
+                               "your rage in the 'reviews' section because that's how the "
+                               'Internet works.',
+                'episodes': [
+                    {
+                        'art': [
+                            {
+                                'aspectRatio': '1',
+                                'autogen': False,
+                                'kind': 'sj#imageRef',
+                                'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5...'
+                            }
+                        ],
+                        'description': 'Sarah Jessica Parker\xa0(Sex and the City) '
+                                       'chats with Chris about growing up without '
+                                       'television, her time on\xa0Square Pegs\xa0and '
+                                       'her character in\xa0L.A. Story. Sarah Jessica '
+                                       'then talks about how she felt when she first '
+                                       'got the part of Carrie on\xa0Sex and the '
+                                       'City,\xa0how she dealt with her sudden '
+                                       'celebrity of being Carrie Bradshaw and they '
+                                       'come up with a crazy theory about the show! '
+                                       'They also talk about Sarah Jessica’s new '
+                                       'show\xa0Divorce\xa0on HBO!',
+                        'durationMillis': '5101000',
+                        'episodeId': 'Dcz67vtkhrerzh4hptfqpadt5vm',
+                        'explicitType': '1',
+                        'fileSize': '40995252',
+                        'publicationTimestampMillis': '1475640000000',
+                        'seriesId': 'Iliyrhelw74vdqrro77kq2vrdhy',
+                        'seriesTitle': 'The Nerdist',
+                        'title': 'Sarah Jessica Parker'
+                    },
+                ]
+                'explicitType': '1',
+                'link': 'http://nerdist.com/',
+                'seriesId': 'Iliyrhelw74vdqrro77kq2vrdhy',
+                'title': 'The Nerdist',
+                'totalNumEpisodes': 829,
+                'userPreferences': {
+                    'autoDownload': False,
+                    'notifyOnNewEpisode': False,
+                    'subscribed': True
+                }
+            }
+
+        """
+
+        return self._make_call(mobileclient.GetPodcastSeries, podcast_series_id, max_episodes)
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1042,6 +1042,43 @@ class Mobileclient(_Base):
 
         return res.get('groups', [])
 
+    def get_browse_podcast_series(self, genre_id='JZCpodcasttopchartall'):
+        """Retrieve podcast series from browse podcasts by genre.
+
+        :param genre_id: A podcast genre id as returned by :func:`get_podcast_browse_hierarchy`.
+          Defaults to Top Chart 'All categories'.
+
+        Returns a list of podcast series dicts.
+
+        Here is an example podcast series dict::
+
+            {
+                'art': [
+                    {
+                        'aspectRatio': '1',
+                        'autogen': False,
+                        'kind': 'sj#imageRef',
+                        'url': 'http://lh3.googleusercontent.com/liR-Pm7EhB58wrAa4uo9Y33LcJJ8keU...'
+                    }
+                ],
+                'author': 'NBC Sports Radio',
+                'continuationToken': '',
+                'description': 'Mike Florio talks about the biggest NFL topics with the '
+                              'people who are most passionate about the game: League execs, '
+                              'players, coaches and the journalists who cover pro football.',
+                'explicitType': '2',
+                'link': 'https://audioboom.com/channel/pro-football-talk-live-with-mike-florio',
+                'seriesId': 'I3iad5heqorm3nck6yp7giruc5i',
+                'title': 'Pro Football Talk Live with Mike Florio',
+                'totalNumEpisodes': 0
+            }
+
+        """
+
+        res = self._make_call(mobileclient.ListBrowsePodcastSeries, id=genre_id)
+
+        return res.get('series', [])
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -953,6 +953,95 @@ class Mobileclient(_Base):
 
         return self._make_call(mobileclient.ListListenNowSituations)['situations']
 
+    def get_browse_podcast_hierarchy(self):
+        """Retrieve the hierarchy of podcast browse genres.
+
+        Returns a list of podcast genres and subgenres::
+
+            {
+                "groups": [
+                    {
+                        "id": "JZCpodcasttopchart",
+                        "displayName": "Top Charts",
+                        "subgroups": [
+                            {
+                             "id": "JZCpodcasttopchartall",
+                             "displayName": "All categories"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartarts",
+                             "displayName": "Arts"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartbusiness",
+                             "displayName": "Business"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartcomedy",
+                             "displayName": "Comedy"
+                            },
+                            {
+                             "id": "JZCpodcasttopcharteducation",
+                             "displayName": "Education"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartgames",
+                             "displayName": "Games & hobbies"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartgovernment",
+                             "displayName": "Government & organizations"
+                            },
+                            {
+                             "id": "JZCpodcasttopcharthealth",
+                             "displayName": "Health"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartkids",
+                             "displayName": "Kids & families"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartmusic",
+                             "displayName": "Music"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartnews",
+                             "displayName": "News & politics"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartreligion",
+                             "displayName": "Religion & spirituality"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartscience",
+                             "displayName": "Science & medicine"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartsociety",
+                             "displayName": "Society & culture"
+                            },
+                            {
+                             "id": "JZCpodcasttopchartsports",
+                             "displayName": "Sports & recreation"
+                            },
+                            {
+                             "id": "JZCpodcasttopcharttechnology",
+                             "displayName": "Technology"
+                            },
+                            {
+                             "id": "JZCpodcasttopcharttv",
+                             "displayName": "TV & film"
+                            }
+                        ]
+                    }
+                ]
+            }
+        """
+
+        res = self._make_call(mobileclient.GetBrowsePodcastHierarchy)
+
+        return res.get('groups', [])
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1104,11 +1104,11 @@ class Mobileclient(_Base):
           **Registering a device id that you do not own is likely a violation of the TOS.**
 
         :param incremental: if True, return a generator that yields lists
-          of at most 1000 playlists
+          of at most 1000 podcast series
           as they are retrieved from the server. This can be useful for
           presenting a loading bar to a user.
 
-        :param include_deleted: if True, include playlists that have been deleted
+        :param include_deleted: if True, include podcast series that have been deleted
           in the past.
 
         :param updated_after: a datetime.datetime; defaults to unix epoch
@@ -1179,11 +1179,11 @@ class Mobileclient(_Base):
           **Registering a device id that you do not own is likely a violation of the TOS.**
 
         :param incremental: if True, return a generator that yields lists
-          of at most 1000 playlists
+          of at most 1000 podcast episodes
           as they are retrieved from the server. This can be useful for
           presenting a loading bar to a user.
 
-        :param include_deleted: if True, include playlists that have been deleted
+        :param include_deleted: if True, include podcast episodes that have been deleted
           in the past.
 
         :param updated_after: a datetime.datetime; defaults to unix epoch
@@ -1607,7 +1607,7 @@ class Mobileclient(_Base):
           The maximum accepted value is 100. If set higher, results are limited to 10.
 
         The results are returned in a dictionary with keys:
-        ``album_hits, artist_hits, playlist_hits, podcast hits,
+        ``album_hits, artist_hits, playlist_hits, podcast_hits,
           situation_hits, song_hits, station_hits, video_hits``
         containing lists of results of that type.
 

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1154,6 +1154,73 @@ class Mobileclient(_Base):
                                    include_deleted=include_deleted, updated_after=updated_after,
                                    device_id=device_id)
 
+    def get_all_podcast_episodes(self, device_id=None, incremental=False,
+                                 include_deleted=False, updated_after=None):
+        """Retrieve list of episodes from user-subscribed podcast series.
+
+        :param device_id: (optional) defaults to ``android_id`` from login.
+
+          Otherwise, provide a mobile device id as a string.
+          Android device ids are 16 characters, while iOS ids
+          are uuids with 'ios:' prepended.
+
+          If you have already used Google Music on a mobile device,
+          :func:`Mobileclient.get_registered_devices
+          <gmusicapi.clients.Mobileclient.get_registered_devices>` will provide
+          at least one working id. Omit ``'0x'`` from the start of the string if present.
+
+          Registered computer ids (a MAC address) will not be accepted and will 403.
+
+          Providing an unregistered mobile device id will register it to your account,
+          subject to Google's `device limits
+          <http://support.google.com/googleplay/bin/answer.py?hl=en&answer=1230356>`__.
+          **Registering a device id that you do not own is likely a violation of the TOS.**
+
+        :param incremental: if True, return a generator that yields lists
+          of at most 1000 playlists
+          as they are retrieved from the server. This can be useful for
+          presenting a loading bar to a user.
+
+        :param include_deleted: if True, include playlists that have been deleted
+          in the past.
+
+        :param updated_after: a datetime.datetime; defaults to unix epoch
+
+        Returns a list of podcast episode dicts.
+
+        Here is an example podcast episode dict::
+
+            {
+                'art': [
+                    {
+                        'aspectRatio': '1',
+                        'autogen': False,
+                        'kind': 'sj#imageRef',
+                        'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5W80uMOfq...'
+                    }
+                ],
+                'deleted': False,
+                'description': 'Comedian Bill Burr yelled at Philadelphia, Chris vaguely '
+                               'understands hockey, Jonah understands it even less, and Matt '
+                               'is weirdly not tired of the running "Matt loves the Dave '
+                               'Matthews Band" joke, though I\'m sure all of you are.',
+                'durationMillis': '4310000',
+                'episodeId': 'D6i26frpxu53t2ws3lpbjtpovum',
+                'explicitType': '2',
+                'fileSize': '69064793',
+                'publicationTimestampMillis': '1277791500000',
+                'seriesId': 'Iliyrhelw74vdqrro77kq2vrdhy',
+                'seriesTitle': 'The Nerdist',
+                'title': 'Bill Burr'
+            }
+
+        """
+        device_id = self._ensure_device_id(device_id)
+
+        return self._get_all_items(mobileclient.ListPodcastEpisodes, incremental=incremental,
+                                   include_deleted=include_deleted, updated_after=updated_after,
+                                   device_id=device_id)
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1221,6 +1221,87 @@ class Mobileclient(_Base):
                                    include_deleted=include_deleted, updated_after=updated_after,
                                    device_id=device_id)
 
+    # TODO: Support multiple.
+    @utils.enforce_id_param
+    def add_podcast_series(self, podcast_id, notify_on_new_episode=False):
+        """Subscribe to a podcast series.
+
+        :param podcast_id: A podcast series id (hint: they always start with 'I').
+        :param notify_on_new_episode: Get device notifications on new episodes.
+
+        Returns podcast series id of added podcast series
+        """
+
+        mutate_call = mobileclient.BatchMutatePodcastSeries
+        update_mutations = mutate_call.build_podcast_updates([
+            {
+                'seriesId': podcast_id,
+                'subscribed': True,
+                'userPreferences': {
+                    'subscribed': True,
+                    'notifyOnNewEpisode': notify_on_new_episode
+                }
+            }
+        ])
+
+        res = self._make_call(mutate_call, update_mutations)
+
+        return res['mutate_response'][0]['id']
+
+    # TODO: Support multiple.
+    @utils.enforce_id_param
+    def delete_podcast_series(self, podcast_id):
+        """Unsubscribe to a podcast series.
+
+        :param podcast_id: A podcast series id (hint: they always start with 'I').
+
+        Returns podcast series id of removed podcast series
+        """
+
+        mutate_call = mobileclient.BatchMutatePodcastSeries
+        update_mutations = mutate_call.build_podcast_updates([
+            {
+                'seriesId': podcast_id,
+                'subscribed': False,
+                'userPreferences': {
+                    'subscribed': False,
+                    'notifyOnNewEpisode': False
+                }
+            }
+        ])
+
+        res = self._make_call(mutate_call, update_mutations)
+
+        return res['mutate_response'][0]['id']
+
+    # TODO: Support multiple.
+    @utils.enforce_id_param
+    def edit_podcast_series(self, podcast_id, subscribe=True, notify_on_new_episode=False):
+        """Edit a podcast series subscription.
+
+        :param podcast_id: A podcast series id (hint: they always start with 'I').
+        :param subscribe: Subscribe to podcast.
+        :param notify_on_new_episode: Get device notifications on new episodes.
+
+        Returns podcast series id of edited podcast series
+        """
+
+        mutate_call = mobileclient.BatchMutatePodcastSeries
+        update_mutations = mutate_call.build_podcast_updates([
+            {
+                'seriesId': podcast_id,
+                'subscribed': subscribe,
+                'userPreferences': {
+                    'subscribed': subscribe,
+                    'notifyOnNewEpisode': notify_on_new_episode
+                }
+            }
+        ])
+
+        res = self._make_call(mutate_call, update_mutations)
+
+        return res['mutate_response'][0]['id']
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from past.builtins import basestring
 from builtins import *  # noqa

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1382,17 +1382,17 @@ class Mobileclient(_Base):
                                 'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5...'
                             }
                         ],
-                        'description': 'Sarah Jessica Parker\xa0(Sex and the City) '
+                        'description': 'Sarah Jessica Parker (Sex and the City) '
                                        'chats with Chris about growing up without '
-                                       'television, her time on\xa0Square Pegs\xa0and '
-                                       'her character in\xa0L.A. Story. Sarah Jessica '
+                                       'television, her time on Square Pegs and '
+                                       'her character in L.A. Story. Sarah Jessica '
                                        'then talks about how she felt when she first '
-                                       'got the part of Carrie on\xa0Sex and the '
-                                       'City,\xa0how she dealt with her sudden '
+                                       'got the part of Carrie on Sex and the '
+                                       'City, how she dealt with her sudden '
                                        'celebrity of being Carrie Bradshaw and they '
                                        'come up with a crazy theory about the show! '
                                        'They also talk about Sarah Jessica’s new '
-                                       'show\xa0Divorce\xa0on HBO!',
+                                       'show Divorce on HBO!',
                         'durationMillis': '5101000',
                         'episodeId': 'Dcz67vtkhrerzh4hptfqpadt5vm',
                         'explicitType': '1',
@@ -1435,17 +1435,17 @@ class Mobileclient(_Base):
                         'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5...'
                     }
                 ],
-                'description': 'Sarah Jessica Parker\xa0(Sex and the City) '
+                'description': 'Sarah Jessica Parker (Sex and the City) '
                                'chats with Chris about growing up without '
-                               'television, her time on\xa0Square Pegs\xa0and '
-                               'her character in\xa0L.A. Story. Sarah Jessica '
+                               'television, her time on Square Pegs and '
+                               'her character in L.A. Story. Sarah Jessica '
                                'then talks about how she felt when she first '
-                               'got the part of Carrie on\xa0Sex and the '
-                               'City,\xa0how she dealt with her sudden '
+                               'got the part of Carrie on Sex and the '
+                               'City, how she dealt with her sudden '
                                'celebrity of being Carrie Bradshaw and they '
                                'come up with a crazy theory about the show! '
                                'They also talk about Sarah Jessica’s new '
-                               'show\xa0Divorce\xa0on HBO!',
+                               'show Divorce on HBO!',
                 'durationMillis': '5101000',
                 'episodeId': 'Dcz67vtkhrerzh4hptfqpadt5vm',
                 'explicitType': '1',

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1079,6 +1079,81 @@ class Mobileclient(_Base):
 
         return res.get('series', [])
 
+    def get_all_podcast_series(self, device_id=None, incremental=False,
+                               include_deleted=False, updated_after=None):
+        """Retrieve list of user-subscribed podcast series.
+
+        :param device_id: (optional) defaults to ``android_id`` from login.
+
+          Otherwise, provide a mobile device id as a string.
+          Android device ids are 16 characters, while iOS ids
+          are uuids with 'ios:' prepended.
+
+          If you have already used Google Music on a mobile device,
+          :func:`Mobileclient.get_registered_devices
+          <gmusicapi.clients.Mobileclient.get_registered_devices>` will provide
+          at least one working id. Omit ``'0x'`` from the start of the string if present.
+
+          Registered computer ids (a MAC address) will not be accepted and will 403.
+
+          Providing an unregistered mobile device id will register it to your account,
+          subject to Google's `device limits
+          <http://support.google.com/googleplay/bin/answer.py?hl=en&answer=1230356>`__.
+          **Registering a device id that you do not own is likely a violation of the TOS.**
+
+        :param incremental: if True, return a generator that yields lists
+          of at most 1000 playlists
+          as they are retrieved from the server. This can be useful for
+          presenting a loading bar to a user.
+
+        :param include_deleted: if True, include playlists that have been deleted
+          in the past.
+
+        :param updated_after: a datetime.datetime; defaults to unix epoch
+
+        Returns a list of podcast series dicts.
+
+        Here is an example podcast series dict::
+
+            {
+                'art': [
+                    {
+                        'aspectRatio': '1',
+                        'autogen': False,
+                        'kind': 'sj#imageRef',
+                        'url': 'http://lh3.googleusercontent.com/bNoyxoGTwCGkUscMjHsvKe5W80uMOfq...'
+                    }
+                ],
+                'author': 'Chris Hardwick',
+                'continuationToken': '',
+                'description': 'I am Chris Hardwick. I am on TV a lot and have a blog at '
+                               'nerdist.com. This podcast is basically just me talking about '
+                               'stuff and things with my two nerdy friends Jonah Ray and Matt '
+                               'Mira, and usually someone more famous than all of us. '
+                               'Occasionally we swear because that is fun. I hope you like '
+                               "it, but if you don't I'm sure you will not hesitate to unfurl "
+                               "your rage in the 'reviews' section because that's how the "
+                               'Internet works.',
+                'explicitType': '1',
+                'link': 'http://nerdist.com/',
+                'seriesId': 'Iliyrhelw74vdqrro77kq2vrdhy',
+                'title': 'The Nerdist',
+                'totalNumEpisodes': 829,
+                'userPreferences': {
+                    'autoDownload': False,
+                    'notifyOnNewEpisode': False,
+                    'subscribed': True
+                }
+            }
+
+        """
+
+        device_id = self._ensure_device_id(device_id)
+
+        return self._get_all_items(mobileclient.ListPodcastSeries, incremental=incremental,
+                                   include_deleted=include_deleted, updated_after=updated_after,
+                                   device_id=device_id)
+
     def create_station(self, name,
                        track_id=None, artist_id=None, album_id=None,
                        genre_id=None, playlist_token=None, curated_station_id=None):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1605,8 +1605,8 @@ class Mobileclient(_Base):
           The maximum accepted value is 100. If set higher, results are limited to 10.
 
         The results are returned in a dictionary with keys:
-        ``album_hits, artist_hits, playlist_hits, situation_hits,
-        song_hits, station_hits, video_hits``
+        ``album_hits, artist_hits, playlist_hits, podcast hits,
+          situation_hits, song_hits, station_hits, video_hits``
         containing lists of results of that type.
 
         Free account search is restricted so may not contain hits for all result types.
@@ -1667,6 +1667,39 @@ class Mobileclient(_Base):
                         'type': 'SHARED'
                     },
                     'type': '4'
+                }],
+                'podcast_hits': [{
+                    'series': {
+                        'art': [
+                            {
+                                'aspectRatio': '1',
+                                'autogen': False,
+                                'kind': 'sj#imageRef',
+                                'url': 'https://lh3.googleusercontent.com/je4lsaiQCdfcOWoYm3Z_mC...'
+                            }
+                        ],
+                        'author': 'Steve Boyett',
+                        'continuationToken': '',
+                        'copyright': 'Music copyright c the respective artists. All other '
+                                     'material c2006, 2016 by Podrunner, LLC. All rights '
+                                     'reserved. For personal use only. Unauthorized '
+                                     'reproduction, sale, rental, exchange, public '
+                                     'performance, or broadcast of this audio is '
+                                     'prohibited.',
+                        'description': 'Nonstop, one-hour, high-energy workout music mixes '
+                                       "to help you groove while you move. Podrunner's "
+                                       'fixed-tempo and interval exercise mixes are '
+                                       'perfect for power walking, jogging, running, '
+                                       'spinning, elliptical, aerobics, and many other '
+                                       'tempo-based forms of exercise. An iTunes '
+                                       'award-winner six years in a row!',
+                        'explicitType': '2',
+                        'link': 'http://www.podrunner.com/',
+                        'seriesId': 'Ilx4ufdua5rdvzplnojtloulo3a',
+                        'title': 'PODRUNNER: Workout Music',
+                        'totalNumEpisodes': 0
+                    },
+                    'type': '9'
                 }],
                 'situation_hits': [{
                     'situation': {
@@ -1779,6 +1812,7 @@ class Mobileclient(_Base):
         return {'album_hits': hits_by_type['3'],
                 'artist_hits': hits_by_type['2'],
                 'playlist_hits': hits_by_type['4'],
+                'podcast_hits': hits_by_type['9'],
                 'situation_hits': hits_by_type['7'],
                 'song_hits': hits_by_type['1'],
                 'station_hits': hits_by_type['6'],

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1302,6 +1302,49 @@ class Mobileclient(_Base):
 
         return res['mutate_response'][0]['id']
 
+    @utils.enforce_id_param
+    def get_podcast_episode_stream_url(self, podcast_episode_id, device_id=None, quality='hi'):
+        """Returns a url that will point to an mp3 file.
+
+        :param podcast_episde_id: a single podcast episode id (hint: they always start with 'D').
+
+        :param device_id: (optional) defaults to ``android_id`` from login.
+
+          Otherwise, provide a mobile device id as a string.
+          Android device ids are 16 characters, while iOS ids
+          are uuids with 'ios:' prepended.
+
+          If you have already used Google Music on a mobile device,
+          :func:`Mobileclient.get_registered_devices
+          <gmusicapi.clients.Mobileclient.get_registered_devices>` will provide
+          at least one working id. Omit ``'0x'`` from the start of the string if present.
+
+          Registered computer ids (a MAC address) will not be accepted and will 403.
+
+          Providing an unregistered mobile device id will register it to your account,
+          subject to Google's `device limits
+          <http://support.google.com/googleplay/bin/answer.py?hl=en&answer=1230356>`__.
+          **Registering a device id that you do not own is likely a violation of the TOS.**
+
+        :param quality: (optional) stream bits per second quality
+          One of three possible values, hi: 320kbps, med: 160kbps, low: 128kbps.
+          The default is hi
+
+        When handling the resulting url, keep in mind that:
+            * you will likely need to handle redirects
+            * the url expires after a minute
+            * only one IP can be streaming music at once.
+              This can result in an http 403 with
+              ``X-Rejected-Reason: ANOTHER_STREAM_BEING_PLAYED``.
+
+        The file will not contain metadata.
+        """
+
+        device_id = self._ensure_device_id(device_id)
+
+        return self._make_call(
+            mobileclient.GetPodcastEpisodeStreamUrl, podcast_episode_id, device_id, quality)
+
     def get_podcast_series_info(self, podcast_series_id, max_episodes=50):
         """Retrieves information about a podcast series.
 

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -31,6 +31,16 @@ class Mobileclient(_Base):
                                            validate,
                                            verify_ssl)
 
+    def _ensure_device_id(self, device_id=None):
+        if device_id is None:
+            device_id = self.android_id
+
+        if len(device_id) == 16 and re.match('^[a-z0-9]*$', device_id):
+            # android device ids are now sent in base 10
+            device_id = str(int(device_id, 16))
+
+        return device_id
+
     @property
     def locale(self):
         """The locale of the Mobileclient session used to localize some responses.
@@ -355,12 +365,7 @@ class Mobileclient(_Base):
         if song_id.startswith('T') and not self.is_subscribed:
             raise NotSubscribed("Store tracks require a subscription to stream.")
 
-        if device_id is None:
-            device_id = self.android_id
-
-        if len(device_id) == 16 and re.match('^[a-z0-9]*$', device_id):
-            # android device ids are now sent in base 10
-            device_id = str(int(device_id, 16))
+        device_id = self._ensure_device_id(device_id)
 
         return self._make_call(mobileclient.GetStreamUrl, song_id, device_id, quality)
 

--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from future.utils import PY3
 from past.builtins import basestring

--- a/gmusicapi/clients/shared.py
+++ b/gmusicapi/clients/shared.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from builtins import *  # noqa
 import logging

--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from future.utils import PY3
 from past.builtins import basestring

--- a/gmusicapi/gmtools/tools.py
+++ b/gmusicapi/gmtools/tools.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """Tools for manipulating client-received Google Music data."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 from builtins import *  # noqa

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -847,7 +847,8 @@ class Search(McCall):
     # The result types returned are requested in the `ct` parameter.
     # Free account search is restricted so may not contain hits for all result types.
     # 1: Song, 2: Artist, 3: Album, 4: Playlist, 6: Station, 7: Situation, 8: Video
-    static_params = {'ct': '1,2,3,4,6,7,8'}
+    # 9: Podcast Series
+    static_params = {'ct': '1,2,3,4,6,7,8,9'}
 
     _res_schema = {
         'type': 'object',

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -795,8 +795,8 @@ class McStreamCall(McCall):
                   'slt': salt,
                   'sig': sig,
                   }
-        if item_id.startswith('T'):
-            # Store track.
+        if item_id.startswith(('T', 'D')):
+            # Store track or podcast episode.
             params['mjck'] = item_id
         else:
             # Library track.
@@ -1348,6 +1348,11 @@ class ListPodcastEpisodes(McListCall):
     @classmethod
     def dynamic_data(cls, device_id=None, updated_after=None, start_token=None, max_results=None):
         pass
+
+
+class GetPodcastEpisodeStreamUrl(McStreamCall):
+    static_method = 'GET'
+    static_url = sj_stream_url + 'fplay'
 
 
 class ListStations(McListCall):

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1295,6 +1295,44 @@ class ListPodcastSeries(McListCall):
         pass
 
 
+# The podcastseries and podcastepisode list calls are strange in that they require a device
+# ID and pass updated-min, max-results, and start-token as params.
+# The start-token param is required, even if not given, to get a result for more than one
+# call in a session.
+class ListPodcastEpisodes(McListCall):
+    item_schema = sj_podcast_episode
+    filter_text = 'podcast episodes'
+
+    static_method = 'GET'
+    static_url = sj_url + 'podcastepisode'
+
+    @staticmethod
+    def dynamic_headers(device_id, updated_after=None, start_token=None, max_results=None):
+        return {'X-Device-ID': device_id}
+
+    @classmethod
+    def dynamic_params(cls, device_id=None, updated_after=None, start_token=None, max_results=None):
+        params = {}
+
+        if updated_after is None:
+            microseconds = 0
+        else:
+            microseconds = utils.datetime_to_microseconds(updated_after)
+
+        params['updated-min'] = microseconds
+
+        params['start-token'] = start_token
+
+        if max_results is not None:
+            params['max-results'] = str(max_results)
+
+        return params
+
+    @classmethod
+    def dynamic_data(cls, device_id=None, updated_after=None, start_token=None, max_results=None):
+        pass
+
+
 class ListStations(McListCall):
     item_schema = sj_station
     filter_text = 'stations'

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1497,6 +1497,21 @@ class BatchMutateTracks(McBatchMutateCall):
         return {'create': track_dict}
 
 
+class GetPodcastSeries(McCall):
+    static_method = 'GET'
+    static_url = sj_url + 'podcast/fetchseries'
+    static_headers = {'Content-Type': 'application/json'}
+    static_params = {'alt': 'json'}
+
+    _res_schema = sj_podcast_series
+
+    @staticmethod
+    def dynamic_params(podcast_series_id, num_episodes):
+        return {
+            'nid': podcast_series_id,
+            'num': num_episodes}
+
+
 class GetStoreTrack(McCall):
     # TODO does this accept library ids, too?
     static_method = 'GET'

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1257,6 +1257,44 @@ class ListBrowsePodcastSeries(McCall):
                     ["<%s podcasts>" % len(filtered['series'])]
 
 
+# The podcastseries and podcastepisode list calls are strange in that they require a device
+# ID and pass updated-min, max-results, and start-token as params.
+# The start-token param is required, even if not given, to get a result for more than one
+# call in a session.
+class ListPodcastSeries(McListCall):
+    item_schema = sj_podcast_series
+    filter_text = 'podcast series'
+
+    static_method = 'GET'
+    static_url = sj_url + 'podcastseries'
+
+    @staticmethod
+    def dynamic_headers(device_id, updated_after=None, start_token=None, max_results=None):
+        return {'X-Device-ID': device_id}
+
+    @classmethod
+    def dynamic_params(cls, device_id=None, updated_after=None, start_token=None, max_results=None):
+        params = {}
+
+        if updated_after is None:
+            microseconds = 0
+        else:
+            microseconds = utils.datetime_to_microseconds(updated_after)
+
+        params['updated-min'] = microseconds
+
+        params['start-token'] = start_token
+
+        if max_results is not None:
+            params['max-results'] = str(max_results)
+
+        return params
+
+    @classmethod
+    def dynamic_data(cls, device_id=None, updated_after=None, start_token=None, max_results=None):
+        pass
+
+
 class ListStations(McListCall):
     item_schema = sj_station
     filter_text = 'stations'

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1257,6 +1257,23 @@ class ListBrowsePodcastSeries(McCall):
                     ["<%s podcasts>" % len(filtered['series'])]
 
 
+class BatchMutatePodcastSeries(McBatchMutateCall):
+    static_method = 'POST'
+    static_url = sj_url + 'podcastseries/batchmutate'
+
+    @staticmethod
+    def build_podcast_updates(updates):
+        """
+        :param updates:
+          [
+            {'seriesId': '', 'subscribed': '', 'userPreferences': {
+             'notifyOnNewEpisode': '', 'subscrubed': ''}}...
+          ]
+        """
+
+        return [{'update': update} for update in updates]
+
+
 # The podcastseries and podcastepisode list calls are strange in that they require a device
 # ID and pass updated-min, max-results, and start-token as params.
 # The start-token param is required, even if not given, to get a result for more than one

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -449,6 +449,111 @@ sj_listen_now_item = {
     }
 }
 
+sj_podcast_genre = {
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': {
+        'id': {'type': 'string'},
+        'displayName': {'type': 'string'}
+    }
+}
+
+sj_podcast_genre['properties']['subgroups'] = {
+    'type': 'array',
+    'required': False,
+    'items': sj_podcast_genre
+}
+
+sj_podcast_episode = {
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': {
+        'art': {
+            'type': 'array',
+            'required': False,
+            'items': sj_image
+        },
+        'author': {
+            'type': 'string',
+            'required': False
+        },
+        'deleted': {
+            'type': 'string',
+            'required': False
+        },
+        'description': {
+            'type': 'string',
+            'required': False
+        },
+        'durationMillis': {'type': 'string'},
+        'episodeId': {'type': 'string'},
+        'explicitType': {'type': 'string'},
+        'fileSize': {'type': 'string'},
+        'playbackPositionMillis': {
+            'type': 'string',
+            'required': False
+        },
+        'publicationTimestampMillis': {
+            'type': 'string',
+            'required': False
+        },
+        'seriesId': {'type': 'string'},
+        'seriesTitle': {'type': 'string'},
+        'title': {'type': 'string'}
+    },
+}
+
+sj_podcast_series = {
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': {
+        'art': {
+            'type': 'array',
+            'required': False,
+            'items': sj_image
+        },
+        'author': {'type': 'string'},
+        'continuationToken': {
+            'type': 'string',
+            'required': False,
+            'blank': True
+        },
+        'copyright': {
+            'type': 'string',
+            'required': False
+        },
+        'description': {
+            'type': 'string',
+            'required': False
+        },
+        'episodes': {
+            'type': 'array',
+            'required': False,
+            'items': sj_podcast_episode
+        },
+        'explicitType': {'type': 'string'},
+        'link': {'type': 'string'},
+        'seriesId': {'type': 'string'},
+        'title': {'type': 'string'},
+        'totalNumEpisodes': {'type': 'integer'},
+        'userPreferences': {
+            'type': 'object',
+            'required': False,
+            'properties': {
+                'autoDownload': {
+                    'type': 'boolean',
+                    'required': False
+                },
+                'notifyOnNewEpisode': {
+                    'type': 'boolean',
+                    'required': False
+                },
+                'subscribed': {'type': 'boolean'}
+            }
+        }
+    }
+}
+
 sj_situation = {
     'type': 'object',
     'additionalProperties': False,
@@ -484,6 +589,7 @@ sj_search_result = {
         'album': sj_album.copy(),
         'track': sj_track.copy(),
         'playlist': sj_playlist.copy(),
+        'series': sj_podcast_series.copy(),
         'station': sj_station.copy(),
         'situation': sj_situation.copy(),
         'youtube_video': sj_video.copy()
@@ -494,6 +600,7 @@ sj_search_result['properties']['artist']['required'] = False
 sj_search_result['properties']['album']['required'] = False
 sj_search_result['properties']['track']['required'] = False
 sj_search_result['properties']['playlist']['required'] = False
+sj_search_result['properties']['series']['required'] = False
 sj_search_result['properties']['station']['required'] = False
 sj_search_result['properties']['situation']['required'] = False
 sj_search_result['properties']['youtube_video']['required'] = False

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1512,6 +1512,19 @@ class GetPodcastSeries(McCall):
             'num': num_episodes}
 
 
+class GetPodcastEpisode(McCall):
+    static_method = 'GET'
+    static_url = sj_url + 'podcast/fetchepisode'
+    static_headers = {'Content-Type': 'application/json'}
+    static_params = {'alt': 'json'}
+
+    _res_schema = sj_podcast_episode
+
+    @staticmethod
+    def dynamic_params(podcast_episode_id):
+        return {'nid': podcast_episode_id}
+
+
 class GetStoreTrack(McCall):
     # TODO does this accept library ids, too?
     static_method = 'GET'

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 """Calls made by the mobile client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 from six import raise_from

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1229,6 +1229,34 @@ class GetBrowsePodcastHierarchy(McCall):
     }
 
 
+class ListBrowsePodcastSeries(McCall):
+    static_method = 'GET'
+    static_url = sj_url + 'podcast/browse'
+    static_params = {'alt': 'json'}
+
+    _res_schema = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'series': {
+                'type': 'array',
+                'items': {'type': sj_podcast_series}
+            }
+        }
+    }
+
+    @classmethod
+    def dynamic_params(cls, id=None):
+        return {'id': id}
+
+    @staticmethod
+    def filter_response(msg):
+        filtered = copy.deepcopy(msg)
+        if 'series' in filtered:
+            filtered['series'] = \
+                    ["<%s podcasts>" % len(filtered['series'])]
+
+
 class ListStations(McListCall):
     item_schema = sj_station
     filter_text = 'stations'

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1211,6 +1211,24 @@ class ListListenNowSituations(McCall):
         return filtered
 
 
+class GetBrowsePodcastHierarchy(McCall):
+    static_method = 'GET'
+    static_url = sj_url + 'podcast/browsehierarchy'
+    static_params = {'alt': 'json'}
+
+    _res_schema = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'groups': {
+                'type': 'array',
+                'required': False,  # Only on errors
+                'items': sj_podcast_genre
+            }
+        }
+    }
+
+
 class ListStations(McListCall):
     item_schema = sj_station
     filter_text = 'stations'

--- a/gmusicapi/test/run_tests.py
+++ b/gmusicapi/test/run_tests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 from __future__ import print_function, division, absolute_import, unicode_literals
 from future.utils import PY3, bind_method
 from builtins import *  # noqa


### PR DESCRIPTION
It's been a long road, but it's finally over... probably.

Besides all the podcast functionality, there were a few background changes that I'll mention:

* Factored out most of the stream call code into its own base call since podcast episode streaming uses ``fplay`` instead of ``mplay``.
* Refactored ``Mobileclient._get_all_items_incremental`` to support the podcast calls which Google felt like making inconsistent with the other list item calls. All tests and functionality seem to have survived it.
* Since it's now used in more places, I moved the code to check for ``device_id`` parameters and format Android IDs into its own private method.

Let me know if you spot anything.