### PR TITLE
Podcast fixes

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -533,7 +533,10 @@ sj_podcast_series = {
             'items': sj_podcast_episode
         },
         'explicitType': {'type': 'string'},
-        'link': {'type': 'string'},
+        'link': {
+            'type': 'string',
+            'required': False
+        },
         'seriesId': {'type': 'string'},
         'title': {'type': 'string'},
         'totalNumEpisodes': {'type': 'integer'},

--- a/gmusicapi/test/server_tests.py
+++ b/gmusicapi/test/server_tests.py
@@ -53,7 +53,7 @@ TEST_PODCAST_SERIES_ID = 'Iliyrhelw74vdqrro77kq2vrdhy'
 
 # An episode of Note to Self.
 # Picked because it's very short (~4 minutes).
-TEST_PODCAST_EPISODE_ID = 'D6m6ruf4hiojsms5nkc7hpeslvi'
+TEST_PODCAST_EPISODE_ID = 'Diksw5cywxflebfs3dbiiabfphu'
 TEST_PODCAST_EPISODE_HASH = 'e8ff4efd6a3a6a1017b35e0ef564d840'
 
 # Amorphis


### PR DESCRIPTION
The ID for the test podcast episode somehow changed. I'm hoping this was just a fluke occurrence, but... Google. At least we know the functionality is fine.