### PR TITLE
No file-logging on IOError

### DIFF
--- a/gmusicapi/utils/utils.py
+++ b/gmusicapi/utils/utils.py
@@ -328,7 +328,7 @@ def configure_debug_log_handlers(logger):
     try:
         make_sure_path_exists(os.path.dirname(log_filepath), 0o700)
         debug_handler = logging.FileHandler(log_filepath)
-    except OSError:
+    except (OSError, IOError):
         logging_to_file = False
         debug_handler = logging.StreamHandler()
 


### PR DESCRIPTION
With f.e. my kodi add-on I can **not** ensure write-access on some OSs (windows might require admin privileges etc.) hence I end up with a crash like:
```
File "gmusicapi/utils/utils.py", line 330, in configure_debug_log_handlers
 debug_handler = logging.FileHandler(log_filepath)
 File "/usr/lib/python2.7/logging/__init__.py", line 913, in __init__
 File "/usr/lib/python2.7/logging/__init__.py", line 943, in _open
IOError: [Errno 30] Read-only file system: u'/gmusicapi.log'
-->End of Python script error report<--
```
This PR fixes that...