### PR TITLE
Fix IFL radio not refreshing seed

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -1408,6 +1408,16 @@ class ListStationTracks(McCall):
         # but then that might introduce paging?
         # I'll leave it for someone else
 
+        if station_id == 'IFL':
+            return json.dumps({'contentFilter': 1,
+                               'stations': [
+                                   {
+                                       'numEntries': num_entries,
+                                       'recentlyPlayed': recently_played,
+                                       'seed': {'seedType': 6}
+                                   }
+                               ]})
+
         return json.dumps({'contentFilter': 1,
                            'stations': [
                                {


### PR DESCRIPTION
Backwards-compatible fix for the "I'm Feeling Lucky" radio station not refreshing its seed each time it is requested - #393 
The format for getting tracks for this radio station has changed, instead of using the magic "IFL" string, the radioId property is omitted and a `seed: {seedType: 6} ` property is included (not entirely sure what the 6 signifies)