### PR TITLE
Update calls to static method for tie_breaker

### DIFF
--- a/gmusicapi/gmtools/tools.py
+++ b/gmusicapi/gmtools/tools.py
@@ -315,12 +315,12 @@ class SongMatcher(object):
                         try:
                             current_mods.append(next(future_mods))
                         except StopIteration:
-                            raise self.TieBroken(tie_breaker(query, results))
+                            raise self.TieBroken(tie_breaker.__func__(query, results))
 
                         next_results = self.query_library(query, tie_breaker, current_mods, auto)
 
                         if not next_results:
-                            raise self.TieBroken(tie_breaker(query, results))
+                            raise self.TieBroken(tie_breaker.__func__(query, results))
                         else:
                             return next_results
         except self.TieBroken as tie:


### PR DESCRIPTION
I'm adding this because after using your great playlist importer in conjunction with gmusicapi, I was getting exceptions when using it for certain queries.

`TypeError: 'staticmethod' object is not callable`

I'm no python expert but after some StackOverflow'ing, this seems somewhat acceptable. (https://stackoverflow.com/a/12718272). Apparently also added to https://docs.python.org/2/whatsnew/2.7.html#other-language-changes