### PR TITLE
Only Add To Matches If Result

### DIFF
--- a/gmusicapi/gmtools/tools.py
+++ b/gmusicapi/gmtools/tools.py
@@ -398,7 +398,9 @@ class SongMatcher(object):
 
         for query in queries:
             res = self.query_library(query, tie_breaker, auto=auto)
-            matches += res
+            
+            if res:
+                matches += res
 
             # Log the results.
 

--- a/gmusicapi/gmtools/tools.py
+++ b/gmusicapi/gmtools/tools.py
@@ -398,7 +398,7 @@ class SongMatcher(object):
 
         for query in queries:
             res = self.query_library(query, tie_breaker, auto=auto)
-            
+
             if res:
                 matches += res
 


### PR DESCRIPTION
Fixes the error found below. Script just dies midway without this.

```
Traceback (most recent call last):
  File "import.py", line 92, in <module>
    main()
  File "import.py", line 79, in main
    matched_songs = matcher.match(queries)
  File "/Library/Python/2.7/site-packages/gmusicapi/gmtools/tools.py", line 401, in match
    matches += res
TypeError: 'NoneType' object is not iterable
```