### PR TITLE
Catch exception when returned session error is not structured as expected

### DIFF
--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -457,12 +457,11 @@ class GetUploadSession(MmCall):
             return (True, None)
 
         if 'errorMessage' in res:
-
             try:
                 # This terribly nested structure is Google's doing.
                 error_code = (res['errorMessage']['additionalInfo']
-                          ['uploader_service.GoogleRupioAdditionalInfo']
-                          ['completionInfo']['customerSpecificInfo']['ResponseCode'])
+                              ['uploader_service.GoogleRupioAdditionalInfo']['completionInfo']
+                              ['customerSpecificInfo']['ResponseCode'])
             except KeyError:
                 # Nested structure not as we expect: probably a 503, should retry
                 error_code = 503

--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -463,8 +463,8 @@ class GetUploadSession(MmCall):
                               ['uploader_service.GoogleRupioAdditionalInfo']['completionInfo']
                               ['customerSpecificInfo']['ResponseCode'])
             except KeyError:
-                # Nested structure not as we expect: probably a 503, should retry
-                error_code = 503
+                # The returned nested structure is not as expected: cannot get Response Code
+                error_code = None
 
             got_session = False
 

--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -457,10 +457,15 @@ class GetUploadSession(MmCall):
             return (True, None)
 
         if 'errorMessage' in res:
-            # This terribly nested structure is Google's doing.
-            error_code = (res['errorMessage']['additionalInfo']
+
+            try:
+                # This terribly nested structure is Google's doing.
+                error_code = (res['errorMessage']['additionalInfo']
                           ['uploader_service.GoogleRupioAdditionalInfo']
                           ['completionInfo']['customerSpecificInfo']['ResponseCode'])
+            except KeyError:
+                # Nested structure not as we expect: probably a 503, should retry
+                error_code = 503
 
             got_session = False
 


### PR DESCRIPTION
Sometimes the session error is not the "horribly nested structure" that we expect. In this case it's probably best to classify it as a 503 and retry.

See issue #570