### PR TITLE
Use AAC and ALAC content types when filling track info

### DIFF
--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -215,6 +215,16 @@ class UploadMetadata(MmCall):
 
         track.client_id = cls.get_track_clientid(filepath)
 
+        audio = mutagen.File(filepath, easy=True)
+
+        if audio is None:
+            raise ValueError("could not open to read metadata")
+        elif isinstance(audio, mutagen.asf.ASF):
+            # WMA entries store more info than just the value.
+            # Monkeypatch in a dict {key: value} to keep interface the same for all filetypes.
+            asf_dict = dict((k, [ve.value for ve in v]) for (k, v) in audio.tags.as_dict().items())
+            audio.tags = asf_dict
+
         extension = os.path.splitext(filepath)[1].upper()
 
         if isinstance(extension, bytes):
@@ -223,6 +233,12 @@ class UploadMetadata(MmCall):
         if extension:
             # Trim leading period if it exists (ie extension not empty).
             extension = extension[1:]
+
+        if isinstance(audio, mutagen.mp4.MP4) and (
+                audio.info.codec == 'alac' or audio.info.codec_description == 'ALAC'):
+            extension = 'ALAC'
+        elif isinstance(audio, mutagen.mp4.MP4) and audio.info.codec_description.startswith('AAC'):
+            extension = 'AAC'
 
         if extension.upper() == 'M4B':
             # M4B are supported by the music manager, and transcoded like normal.
@@ -241,16 +257,6 @@ class UploadMetadata(MmCall):
         track.client_date_added = 0
         track.recent_timestamp = 0
         track.rating = locker_pb2.Track.NOT_RATED  # star rating
-
-        # Populate information about the encoding.
-        audio = mutagen.File(filepath, easy=True)
-        if audio is None:
-            raise ValueError("could not open to read metadata")
-        elif isinstance(audio, mutagen.asf.ASF):
-            # WMA entries store more info than just the value.
-            # Monkeypatch in a dict {key: value} to keep interface the same for all filetypes.
-            asf_dict = dict((k, [ve.value for ve in v]) for (k, v) in audio.tags.as_dict().items())
-            audio.tags = asf_dict
 
         track.duration_millis = int(audio.info.length * 1000)
 


### PR DESCRIPTION
The protos have these as separate content types than M4A.
Unsure if the difference serves any purpose, but it's easy to set them as such.