### PR TITLE
Update link to Squeezebox plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ That said, it's actively maintained, and powers a bunch of cool projects:
    `gmusicprocurator <https://github.com/malept/gmusicprocurator>`__,
    as well as plugins for 
    `Mopidy <https://github.com/hechtus/mopidy-gmusic>`__,
-   `Squeezebox <https://github.com/hechtus/squeezebox-googlemusic>`__ and
+   `Squeezebox <https://github.com/squeezebox-googlemusic/squeezebox-googlemusic>`__ and
    `Tizonia <https://github.com/tizonia/tizonia-openmax-il>`__.
 -  enhancements like `autoplaylists / smart playlists <https://autoplaylists.simon.codes>`__
 


### PR DESCRIPTION
Update link to Squeezebox plugin as Hechtus is no longer actively maintaining the plugin.