### PR TITLE
Minor code efficiency change in new search implementation

### DIFF
--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1885,8 +1885,7 @@ class Mobileclient(_Base):
         for cluster in clusters:
             hit_type = cluster['cluster']['type']
             hits = cluster.get('entries', [])
-            for hit in hits:
-                hits_by_type[hit_type].append(hit)
+            hits_by_type[hit_type].extend(hits)
 
         return {'album_hits': hits_by_type['3'],
                 'artist_hits': hits_by_type['2'],


### PR DESCRIPTION
Didn't think of this until after my previous PR.

Since we're now getting the result type from the cluster information, we don't need to manually loop through all the results; just use list.extend instead.