### PR TITLE
Prune deps: six, future and mock

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from getpass import getpass
 

--- a/gmusicapi/appdirs.py
+++ b/gmusicapi/appdirs.py
@@ -4,7 +4,6 @@
 Mock version of appdirs for use in cases without the real version
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 try:
     from appdirs import AppDirs

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from past.builtins import basestring
 from builtins import *  # noqa
 from collections import defaultdict
 import datetime
@@ -377,7 +376,7 @@ class Mobileclient(_OAuthClient):
         return self.add_store_tracks(store_song_id)[0]
 
     @utils.require_subscription
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.enforce_ids_param
     def add_store_tracks(self, store_song_ids):
         """Add store tracks to the library
@@ -395,7 +394,7 @@ class Mobileclient(_OAuthClient):
 
         return [r['id'] for r in res['mutate_response']]
 
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.enforce_ids_param
     @utils.empty_arg_shortcircuit
     def delete_songs(self, library_song_ids):
@@ -682,7 +681,7 @@ class Mobileclient(_OAuthClient):
 
         return entries
 
-    @utils.accept_singleton(basestring, 2)
+    @utils.accept_singleton(str, 2)
     @utils.enforce_id_param
     @utils.enforce_ids_param(position=2)
     @utils.empty_arg_shortcircuit(position=2)
@@ -706,7 +705,7 @@ class Mobileclient(_OAuthClient):
 
         return [e['id'] for e in res['mutate_response']]
 
-    @utils.accept_singleton(basestring, 1)
+    @utils.accept_singleton(str, 1)
     @utils.enforce_ids_param(position=1)
     @utils.empty_arg_shortcircuit(position=1)
     def remove_entries_from_playlist(self, entry_ids):
@@ -1659,7 +1658,7 @@ class Mobileclient(_OAuthClient):
 
         return res['mutate_response'][0]['id']
 
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.enforce_ids_param
     @utils.empty_arg_shortcircuit
     def delete_stations(self, station_ids):

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 from collections import defaultdict
 import datetime
 from functools import partial

--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import os
 from socket import gethostname

--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from past.builtins import basestring
 from builtins import *  # noqa
 
 import os
@@ -308,7 +307,7 @@ class Musicmanager(_OAuthClient):
 
         return (client_state.total_track_count, client_state.locker_track_limit)
 
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.empty_arg_shortcircuit(return_code='{}')
     def upload(self, filepaths, enable_matching=False,
                enable_transcoding=True, transcode_quality='320k'):

--- a/gmusicapi/clients/musicmanager.py
+++ b/gmusicapi/clients/musicmanager.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from future.utils import PY3
 from past.builtins import basestring
 from builtins import *  # noqa
 
@@ -9,11 +8,7 @@ import os
 from socket import gethostname
 import time
 from uuid import getnode as getmac
-
-if PY3:
-    from urllib.parse import unquote
-else:
-    from urllib import unquote
+from urllib.parse import unquote
 
 import httplib2  # included with oauth2client
 from oauth2client.client import TokenRevokeError

--- a/gmusicapi/clients/shared.py
+++ b/gmusicapi/clients/shared.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function, division, absolute_import, unicode_literals
 from builtins import *  # noqa
-from past.builtins import basestring
 
 import logging
 import os
@@ -171,7 +170,7 @@ class _OAuthClient(_Base):
     def _oauth_login(self, oauth_credentials):
         """Return True on success."""
 
-        if isinstance(oauth_credentials, basestring):
+        if isinstance(oauth_credentials, str):
             oauth_file = oauth_credentials
             if oauth_file == self.OAUTH_FILEPATH:
                 utils.make_sure_path_exists(os.path.dirname(self.OAUTH_FILEPATH), 0o700)

--- a/gmusicapi/clients/shared.py
+++ b/gmusicapi/clients/shared.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import logging
 import os

--- a/gmusicapi/clients/shared.py
+++ b/gmusicapi/clients/shared.py
@@ -8,13 +8,12 @@ import logging
 import os
 
 from gmusicapi.utils import utils
-from future.utils import with_metaclass
 from oauth2client.client import OAuth2WebServerFlow
 import oauth2client.file
 import webbrowser
 
 
-class _Base(with_metaclass(utils.DocstringInheritMeta, object)):
+class _Base(metaclass=utils.DocstringInheritMeta):
     """Factors out common client setup."""
     _session_class = utils.NotImplementedField
 

--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import warnings
 from urllib.parse import parse_qsl, urlparse

--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from past.builtins import basestring
 from builtins import *  # noqa
 
 import warnings
@@ -215,7 +214,7 @@ class Webclient(_Base):
 
         return bytes(stream_pieces)
 
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.enforce_ids_param
     @utils.empty_arg_shortcircuit
     def report_incorrect_match(self, song_ids):
@@ -235,7 +234,7 @@ class Webclient(_Base):
 
         return song_ids
 
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.enforce_ids_param
     @utils.empty_arg_shortcircuit
     def upload_album_art(self, song_ids, image_filepath):
@@ -339,7 +338,7 @@ class Webclient(_Base):
         res = self._make_call(webclient.GetSettings, '')
         return res['settings']['uploadDevice']
 
-    @utils.accept_singleton(basestring)
+    @utils.accept_singleton(str)
     @utils.enforce_ids_param
     @utils.empty_arg_shortcircuit
     @utils.deprecated('prefer Mobileclient.delete_songs')
@@ -355,7 +354,7 @@ class Webclient(_Base):
 
         return res['deleteIds']
 
-    @utils.accept_singleton(basestring, 2)
+    @utils.accept_singleton(str, 2)
     @utils.enforce_ids_param(2)
     @utils.enforce_id_param
     @utils.empty_arg_shortcircuit(position=2)
@@ -377,7 +376,7 @@ class Webclient(_Base):
 
         return [(e['songId'], e['playlistEntryId']) for e in new_entries]
 
-    @utils.accept_singleton(basestring, 2)
+    @utils.accept_singleton(str, 2)
     @utils.enforce_ids_param(2)
     @utils.enforce_id_param
     @utils.empty_arg_shortcircuit(position=2)
@@ -410,7 +409,7 @@ class Webclient(_Base):
         else:
             return []
 
-    @utils.accept_singleton(basestring, 2)
+    @utils.accept_singleton(str, 2)
     @utils.empty_arg_shortcircuit(position=2)
     def _remove_entries_from_playlist(self, playlist_id, entry_ids_to_remove):
         """Removes entries from a playlist. Returns a list of removed "sid_eid" strings.

--- a/gmusicapi/clients/webclient.py
+++ b/gmusicapi/clients/webclient.py
@@ -1,16 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from future.utils import PY3
 from past.builtins import basestring
 from builtins import *  # noqa
 
 import warnings
-
-if PY3:
-    from urllib.parse import parse_qsl, urlparse
-else:
-    from urlparse import parse_qsl, urlparse
+from urllib.parse import parse_qsl, urlparse
 
 import gmusicapi
 from gmusicapi.clients.shared import _Base

--- a/gmusicapi/exceptions.py
+++ b/gmusicapi/exceptions.py
@@ -2,11 +2,9 @@
 
 """Custom exceptions used across the project."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from future.utils import python_2_unicode_compatible
 from builtins import *  # noqa
 
 
-@python_2_unicode_compatible
 class CallFailure(Exception):
     """Exception raised when a Google Music server responds that a call failed.
 

--- a/gmusicapi/exceptions.py
+++ b/gmusicapi/exceptions.py
@@ -2,7 +2,6 @@
 
 """Custom exceptions used across the project."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 
 class CallFailure(Exception):

--- a/gmusicapi/gmtools/tools.py
+++ b/gmusicapi/gmtools/tools.py
@@ -2,7 +2,6 @@
 
 """Tools for manipulating client-received Google Music data."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import operator
 import re

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -3,7 +3,6 @@
 
 """Calls made by the mobile client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import base64
 import calendar

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -3,7 +3,6 @@
 
 """Calls made by the mobile client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from six import raise_from
 from builtins import *  # noqa
 
 import base64
@@ -671,7 +670,7 @@ class McCall(Call):
         try:
             return validictory.validate(msg, cls._res_schema)
         except ValueError as e:
-            raise_from(ValidationException(str(e)), e)
+            raise ValidationException(str(e)) from e
 
     @classmethod
     def check_success(cls, response, msg):

--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -2,7 +2,6 @@
 
 """Calls made by the Music Manager (related to uploading)."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from six import raise_from
 from builtins import *  # noqa
 
 import base64
@@ -57,7 +56,7 @@ class MmCall(Call):
         try:
             res_msg.ParseFromString(response.content)
         except DecodeError as e:
-            raise_from(ParseException(str(e)), e)
+            raise ParseException(str(e)) from e
 
         return res_msg
 

--- a/gmusicapi/protocol/musicmanager.py
+++ b/gmusicapi/protocol/musicmanager.py
@@ -2,7 +2,6 @@
 
 """Calls made by the Music Manager (related to uploading)."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import base64
 import hashlib

--- a/gmusicapi/protocol/shared.py
+++ b/gmusicapi/protocol/shared.py
@@ -2,7 +2,6 @@
 
 """Definitions shared by multiple clients."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from collections import namedtuple
 

--- a/gmusicapi/protocol/shared.py
+++ b/gmusicapi/protocol/shared.py
@@ -15,7 +15,6 @@ from gmusicapi.exceptions import (
 from gmusicapi.utils import utils
 
 import requests
-from future.utils import with_metaclass
 
 log = utils.DynamicClientLogger(__name__)
 
@@ -98,7 +97,7 @@ class BuildRequestMeta(type):
         return new_cls
 
 
-class Call(with_metaclass(BuildRequestMeta, object)):
+class Call(metaclass=BuildRequestMeta):
     """
     Clients should use Call.perform().
 

--- a/gmusicapi/protocol/shared.py
+++ b/gmusicapi/protocol/shared.py
@@ -3,7 +3,6 @@
 """Definitions shared by multiple clients."""
 from __future__ import print_function, division, absolute_import, unicode_literals
 from builtins import *  # noqa
-from six import raise_from
 
 from collections import namedtuple
 
@@ -262,7 +261,7 @@ class Call(with_metaclass(BuildRequestMeta, object)):
                            e_message=str(e),
                            req_kwargs=safe_req_kwargs,
                            content=response.text)
-            raise_from(CallFailure(err_msg, e.callname), e)
+            raise CallFailure(err_msg, e.callname) from e
 
         except ValidationException as e:
             # TODO shouldn't be using formatting
@@ -291,7 +290,7 @@ class Call(with_metaclass(BuildRequestMeta, object)):
         try:
             return json.loads(text)
         except ValueError as e:
-            raise_from(ParseException(str(e)), e)
+            raise ParseException(str(e)) from e
 
     @staticmethod
     def _filter_proto(msg, make_copy=True):

--- a/gmusicapi/protocol/webclient.py
+++ b/gmusicapi/protocol/webclient.py
@@ -2,7 +2,6 @@
 
 """Calls made by the web client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from six import raise_from
 from builtins import *  # noqa
 
 import base64
@@ -66,7 +65,7 @@ class WcCall(Call):
         try:
             return validictory.validate(msg, cls._res_schema)
         except ValueError as e:
-            raise_from(ValidationException(str(e)), e)
+            raise ValidationException(str(e)) from e
 
     @classmethod
     def check_success(cls, response, msg):

--- a/gmusicapi/protocol/webclient.py
+++ b/gmusicapi/protocol/webclient.py
@@ -2,7 +2,6 @@
 
 """Calls made by the web client."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import base64
 import copy

--- a/gmusicapi/session.py
+++ b/gmusicapi/session.py
@@ -4,7 +4,6 @@
 Sessions handle the details of authentication and transporting requests.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from collections import namedtuple
 from contextlib import closing

--- a/gmusicapi/test/local_tests.py
+++ b/gmusicapi/test/local_tests.py
@@ -8,8 +8,8 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 from collections import namedtuple
 import os
 import time
+from unittest.mock import MagicMock
 
-from mock import MagicMock
 from proboscis.asserts import (
     assert_raises, assert_true, assert_false, assert_equal,
     assert_is_not, Check

--- a/gmusicapi/test/local_tests.py
+++ b/gmusicapi/test/local_tests.py
@@ -4,7 +4,6 @@
 Tests that don't hit the Google Music servers.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from collections import namedtuple
 import os

--- a/gmusicapi/test/rewrite_audiotest_tags.py
+++ b/gmusicapi/test/rewrite_audiotest_tags.py
@@ -3,7 +3,6 @@
 
 """A script that will rewrite audiotest* metadata to match their filenames."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from glob import glob
 import os

--- a/gmusicapi/test/run_tests.py
+++ b/gmusicapi/test/run_tests.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from collections import namedtuple
 import functools

--- a/gmusicapi/test/run_tests.py
+++ b/gmusicapi/test/run_tests.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function, division, absolute_import, unicode_literals
-from future.utils import PY3, bind_method
 from builtins import *  # noqa
 
 from collections import namedtuple
@@ -97,8 +96,8 @@ def retrieve_auth():
 
 def freeze_method_kwargs(klass, method_name, **kwargs):
     method = getattr(klass, method_name)
-    partialfunc = functools.partialmethod if PY3 else functools.partial
-    bind_method(klass, method_name, partialfunc(method, **kwargs))
+    partialfunc = functools.partialmethod
+    setattr(klass, method_name, partialfunc(method, **kwargs))
 
 
 def freeze_login_details(mc_kwargs, mm_kwargs):

--- a/gmusicapi/test/server_tests.py
+++ b/gmusicapi/test/server_tests.py
@@ -7,7 +7,6 @@ Destructive modifications are not made, but if things go terrible wrong,
 an extra test playlist or song may result.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from collections import namedtuple
 import datetime

--- a/gmusicapi/test/utils.py
+++ b/gmusicapi/test/utils.py
@@ -2,7 +2,6 @@
 
 """Utilities used in testing."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import logging
 import os

--- a/gmusicapi/utils/jsarray.py
+++ b/gmusicapi/utils/jsarray.py
@@ -4,7 +4,6 @@
 Tools to handle Google's ridiculous interchange format.
 """
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 from io import StringIO
 from tokenize import generate_tokens

--- a/gmusicapi/utils/utils.py
+++ b/gmusicapi/utils/utils.py
@@ -2,7 +2,6 @@
 
 """Utility functions used across api code."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from builtins import *  # noqa
 
 import ast
 from bisect import bisect_left

--- a/gmusicapi/utils/utils.py
+++ b/gmusicapi/utils/utils.py
@@ -2,7 +2,6 @@
 
 """Utility functions used across api code."""
 from __future__ import print_function, division, absolute_import, unicode_literals
-from past.builtins import basestring
 from builtins import *  # noqa
 
 import ast
@@ -286,7 +285,7 @@ def enforce_id_param(position=1):
     @decorator
     def wrapper(function, *args, **kw):
 
-        if not isinstance(args[position], basestring):
+        if not isinstance(args[position], str):
             raise ValueError("Invalid param type in position %s;"
                              " expected an id (did you pass a dictionary?)" % position)
 
@@ -307,7 +306,7 @@ def enforce_ids_param(position=1):
     def wrapper(function, *args, **kw):
 
         if ((not isinstance(args[position], (list, tuple)) or
-             not all([isinstance(e, basestring) for e in args[position]]))):
+             not all([isinstance(e, str) for e in args[position]]))):
             raise ValueError("Invalid param type in position %s;"
                              " expected ids (did you pass dictionaries?)" % position)
 
@@ -484,7 +483,7 @@ def transcode_to_mp3(filepath, quality='320k', slice_start=None, slice_duration=
 
     if isinstance(quality, int):
         cmd.extend(['-q:a', str(quality)])
-    elif isinstance(quality, basestring):
+    elif isinstance(quality, str):
         cmd.extend(['-b:a', quality])
     else:
         raise ValueError("quality must be int or string, but received %r" % quality)
@@ -538,7 +537,7 @@ def truncate(x, max_els=100, recurse_levels=0):
         if len(x) > max_els:
             if isinstance(x, str):
                 return x[:max_els] + '...'
-            elif isinstance(x, basestring):
+            elif isinstance(x, bytes):
                 return x[:max_els] + b'...'
 
             if isinstance(x, dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 appdirs==1.4.0
 beautifulsoup4==4.5.1
 decorator==4.0.10
-future==0.15.2
 gpsoauth==0.4.0
 httplib2==0.9.2
 MechanicalSoup==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ decorator==4.0.10
 gpsoauth==0.4.0
 httplib2==0.9.2
 MechanicalSoup==0.4.0
-mock==2.0.0
 mutagen==1.34.1
 oauth2client==3.0.0
 pbr==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ pycryptodomex==3.4.2
 python-dateutil==2.5.3
 requests==2.20.0
 rsa==3.4.2
-six==1.10.0
 validictory==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'appdirs >= 1.1.0',                       # user_log_dir
         'gpsoauth >= 0.2.0',                      # mac -> android_id, validation, pycryptodome
         'MechanicalSoup >= 0.4.0',
-        'six >= 1.9.0',                           # raise_from on Python 3
         'future',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'appdirs >= 1.1.0',                       # user_log_dir
         'gpsoauth >= 0.2.0',                      # mac -> android_id, validation, pycryptodome
         'MechanicalSoup >= 0.4.0',
-        'future',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'proboscis >= 1.2.5.1',                   # runs_after
         'protobuf >= 3.0.0',
         'oauth2client >= 1.1',                    # TokenRevokeError
-        'mock >= 0.7.0',                          # MagicMock
         'appdirs >= 1.1.0',                       # user_log_dir
         'gpsoauth >= 0.2.0',                      # mac -> android_id, validation, pycryptodome
         'MechanicalSoup >= 0.4.0',


### PR DESCRIPTION
As I packaged gmusicapi for Debian, I noticed that there are quite a lot of dependencies. Since Python 2 support has recently been removed in the develop branch, this PR follows up by pruning three dependencies that are no longer needed in a pure Python 3 world: `six`, `future`, and `mock`.