### PR TITLE
Uncapped downloads through get_stream_url

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -830,18 +830,24 @@ class McStreamCall(McCall):
 
     @staticmethod
     def dynamic_headers(item_id, device_id, quality):
-        return {'X-Device-ID': device_id}
+        return {'X-Device-ID': device_id,
+                'User-agent': 'Android-Music/8770'}
 
     @classmethod
     def dynamic_params(cls, item_id, device_id, quality):
         sig, salt = cls.get_signature(item_id)
 
         params = {'opt': quality,
-                  'net': 'mob',
-                  'pt': 'e',
+                  'net': 'wifi',
+                  'dt': 'uc',
                   'slt': salt,
                   'sig': sig,
+                  'p': '0',
+                  'adaptive': 'false',
+                  'targetkbps': '512',
+                  'audio_formats': 'mp3'
                   }
+
         if item_id.startswith(('T', 'D')):
             # Store track or podcast episode.
             params['mjck'] = item_id

--- a/gmusicapi/session.py
+++ b/gmusicapi/session.py
@@ -293,7 +293,7 @@ class Mobileclient(Musicmanager):
         # As of API v2.5, dv is a required parameter for all calls.
         # The dv value is part of the Android app version number,
         # but setting this to 0 works fine.
-        req_kwargs['params'].update({'dv': 0})
+        req_kwargs['params'].update({'dv': 87701})
 
         if self._is_subscribed:
             req_kwargs['params'].update({'tier': 'aa'})


### PR DESCRIPTION
Normally these downloads begin returning 403 forbidden after 2-3k downloads per day. Syncing mobile playlists still works however, and these packets go to the same api endpoint. After some snooping, I was able to replicate these packets and now have uncapped downloads.

Some of the changes may not be required, but I haven't had time to test which ones.